### PR TITLE
Docs: align README title with Moltbot rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# clawd.bot
+# Molt.bot
+
+Formerly known as clawd.bot
 
 Landing page for [Moltbot](https://github.com/moltbot/moltbot) — your personal AI assistant.
 


### PR DESCRIPTION
Updates the README title to reflect the Moltbot rename.
Existing domains and install paths are unchanged.
