### PR TITLE
perf: switch to webp.se for optimized avatar delivery

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -103,7 +103,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
           {row1.map((t) => (
             <a href={t.url} target="_blank" rel="noopener" class="testimonial-card">
               <img
-                src={`https://unavatar.io/x/${t.author}`}
+                src={`https://unavatar.webp.se/x/${t.author}`}
                 alt={t.author}
                 class="testimonial-avatar"
                 loading="lazy"
@@ -120,7 +120,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
           {row2.map((t) => (
             <a href={t.url} target="_blank" rel="noopener" class="testimonial-card">
               <img
-                src={`https://unavatar.io/x/${t.author}`}
+                src={`https://unavatar.webp.se/x/${t.author}`}
                 alt={t.author}
                 class="testimonial-avatar"
                 loading="lazy"

--- a/src/pages/shoutouts.astro
+++ b/src/pages/shoutouts.astro
@@ -24,7 +24,7 @@ const allTestimonials = [...testimonials, ...extraTestimonials];
       {allTestimonials.map((t) => (
         <a href={t.url} target="_blank" rel="noopener" class="shoutout-card">
           <img
-            src={t.avatar || `https://unavatar.io/x/${t.author}`}
+            src={t.avatar || `https://unavatar.webp.se/x/${t.author}`}
             alt={t.author}
             class="shoutout-avatar"
             loading="lazy"

--- a/src/pages/showcase.astro
+++ b/src/pages/showcase.astro
@@ -35,7 +35,7 @@ const categoryLabels: Record<string, string> = {
         <a href={`https://x.com/${item.author}/status/${item.id}`} target="_blank" rel="noopener" class="showcase-card">
           <div class="card-header">
             <img
-              src={`https://unavatar.io/x/${item.author}`}
+              src={`https://unavatar.webp.se/x/${item.author}`}
               alt={item.author}
               class="avatar"
               loading="lazy"


### PR DESCRIPTION
this could improve web vitals and save some kb.

**!!! but i must admit i don't know how well https://unavatar.webp.se/ will handle high traffic or if you have a pro plan for unavator.io !!! so this could be a stupid idea... i was just searching for a webp avatar provider ** 

---
https://webp.se/pricing/business/

"If you are adding avatars to a personal project or a medium-sized website, unavatar.webp.se will handle the traffic easily. If you are launching a massive viral application, you should consider using their Consistency Mode or a paid plan to ensure you aren't throttled by the public rate limits."

https://docs.webp.se/public-services/unavatar/
---


.webp version with:
<img width="989" height="717" alt="image" src="https://github.com/user-attachments/assets/007ca5af-5e69-41b1-9abf-65f3eae86c45" />

current jpg avatar image:
<img width="985" height="625" alt="image" src="https://github.com/user-attachments/assets/ae98567a-a3d7-44a4-a4ab-f9771404517f" />
