### PR TITLE
fix(install): create moltbot symlink alongside clawdbot

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -675,6 +675,11 @@ ensure_clawdbot_bin_link() {
         ln -sf "$npm_root/clawdbot/dist/entry.js" "${npm_bin}/clawdbot"
         echo -e "${WARN}→${NC} Installed clawdbot bin link at ${INFO}${npm_bin}/clawdbot${NC}"
     fi
+    # Create moltbot symlink so both commands work
+    if [[ ! -x "${npm_bin}/moltbot" ]]; then
+        ln -sf "$npm_root/clawdbot/dist/entry.js" "${npm_bin}/moltbot"
+        echo -e "${WARN}→${NC} Installed moltbot bin link at ${INFO}${npm_bin}/moltbot${NC}"
+    fi
     return 0
 }
 


### PR DESCRIPTION
## Problem

After running `curl -fsSL https://molt.bot/install.sh | bash`, the installer prints:

```
🦞 Moltbot installed successfully!
```

But running `moltbot onboard` fails with:
```
zsh: command not found: moltbot
```

Users must discover that the actual command is `clawdbot`, which contradicts all the branding.

## Solution

Create a `moltbot` symlink alongside `clawdbot` in `ensure_clawdbot_bin_link()`, pointing to the same `entry.js`. This way both commands work.

## Why not just rename the npm package?

That's the proper long-term fix, but this 5-line change unblocks users immediately while the full migration is in progress.

## Testing

Tested on macOS (Apple Silicon) with fresh install:

```bash
# Before: only clawdbot exists
which clawdbot  # /opt/homebrew/bin/clawdbot
which moltbot   # not found

# After: both work
which clawdbot  # /opt/homebrew/bin/clawdbot  
which moltbot   # /opt/homebrew/bin/moltbot
moltbot --version  # 2026.1.24-3
```

## AI Disclosure

- [x] AI-assisted (Claude Code / Opus 4.5)
- [x] Lightly tested (manual verification on macOS)
- [x] I understand what the code does — it's a 5-line symlink addition