### PR TITLE
fix: rename package name from clawdbot to openclaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@
 
 ## 2026-01-16
 
-- `install.sh`: warn when the user’s original shell `PATH` likely won’t find the installed `clawdbot` binary (common Node/npm global bin issues); link to docs.
+- `install.sh`: warn when the user's original shell `PATH` likely won't find the installed `openclaw` binary (common Node/npm global bin issues); link to docs.
 - CI: add lightweight unit tests for `install.sh` path resolution.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The landing page hosts installer scripts:
 These scripts:
 1. Install Homebrew (macOS) or detect package managers (Windows)
 2. Install Node.js 22+ if needed
-3. Install clawdbot globally via npm
-4. Run `clawdbot doctor --non-interactive` for migrations (upgrades only)
-5. Prompt to run `clawdbot onboard` (new installs)
+3. Install openclaw globally via npm
+4. Run `openclaw doctor --non-interactive` for migrations (upgrades only)
+5. Prompt to run `openclaw onboard` (new installs)
 
 ## Related
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -213,7 +213,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
           <div class="code-line comment" id="quick-comment-install"># Install OpenClaw</div>
           <div class="code-line cmd">
             <span class="code-prompt">$</span>
-            <span class="pm-install">npm i -g clawdbot</span>
+            <span class="pm-install">npm i -g openclaw</span>
             <button class="copy-line-btn" data-cmd="install" title="Copy">
               <svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
               <svg class="check-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><polyline points="20 6 9 17 4 12"/></svg>
@@ -295,8 +295,8 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
 
     <script>
       const installCmds = {
-        npm: 'npm i -g clawdbot',
-        pnpm: 'pnpm add -g clawdbot'
+        npm: 'npm i -g openclaw',
+        pnpm: 'pnpm add -g openclaw'
       };
 
       const windowsPsCmd = 'iwr -useb https://openclaw.ai/install.ps1 | iex';
@@ -371,8 +371,8 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
         // Update quick mode install command (with beta support)
         const betaSuffix = currentBeta ? '@beta' : '';
         const installCmd = currentPm === 'npm'
-          ? `npm i -g clawdbot${betaSuffix}`
-          : `pnpm add -g clawdbot${betaSuffix}`;
+          ? `npm i -g openclaw${betaSuffix}`
+          : `pnpm add -g openclaw${betaSuffix}`;
         document.querySelectorAll('.pm-install').forEach(cmd => cmd.textContent = installCmd);
         // Update one-liner OS command (with beta and shell support)
         let onelinerCmd;
@@ -512,7 +512,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
         },
         'install': () => {
           const betaSuffix = currentBeta ? '@beta' : '';
-          return currentPm === 'npm' ? `npm i -g clawdbot${betaSuffix}` : `pnpm add -g clawdbot${betaSuffix}`;
+          return currentPm === 'npm' ? `npm i -g openclaw${betaSuffix}` : `pnpm add -g openclaw${betaSuffix}`;
         },
         'onboard': () => 'openclaw onboard',
         'hackable-installer': () => "curl -fsSL https://openclaw.ai/install.sh | bash -s -- --install-method git",


### PR DESCRIPTION
Updates all npm/pnpm installation commands to use the correct package name `openclaw` instead of `clawdbot`.

## Changes
- `src/pages/index.astro` - All install commands updated
- `README.md` - Installation instructions updated  
- `CHANGELOG.md` - Binary name reference updated

## Not changed (intentionally)
- External press links (MacStories, StarryHope URLs)
- Newsletter tag `value="clawdbot"` (Buttondown integration)
- Link to `clawdbot-formal-models` GitHub repo