### PR TITLE
fix: use absolute URLs for OG/Twitter image meta on /cat page

### DIFF
--- a/src/pages/cat.astro
+++ b/src/pages/cat.astro
@@ -9,12 +9,15 @@
     <link rel="icon" href="/cat.ico" />
     <meta property="og:title" content="OpenClaw" />
     <meta property="og:description" content="Because Siri wasn't answering at 3AM." />
-    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:image" content="https://openclaw.ai/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://openclaw.ai/cat" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="OpenClaw" />
     <meta name="twitter:description" content="Because Siri wasn't answering at 3AM." />
-    <meta name="twitter:image" content="/og-image.png" />
+    <meta name="twitter:image" content="https://openclaw.ai/og-image.png" />
     <meta http-equiv="refresh" content="0; url=https://www.youtube.com/watch?v=hvL1339luv0" />
   </head>
   <body>


### PR DESCRIPTION
## Problem

The `/cat` page uses relative paths (`/og-image.png`) for `og:image` and `twitter:image` meta tags. Social media crawlers (Twitter, Discord, Telegram, Slack, etc.) require fully qualified URLs to fetch preview images, so the OG image never renders in link previews.

The main layout (`Layout.astro`) already uses absolute URLs correctly — this was just missed on the standalone `/cat` page.

## Changes

- **`og:image` and `twitter:image`**: `/og-image.png` → `https://openclaw.ai/og-image.png`
- **Added `og:image:width`** and **`og:image:height`** (1200×630) for proper preview sizing
- **Added `og:url`** (`https://openclaw.ai/cat`) for canonical URL resolution

## Verification

All other pages use `Layout.astro` which already has absolute OG URLs — `/cat` was the only page affected.

--
![image](https://github.com/user-attachments/assets/df909239-0a50-4b17-abe4-c64e5a1b605d)

> openclaw.ai

![image](https://github.com/user-attachments/assets/868e4e2b-7b4a-4a58-b36d-7ea877060259)

> openclaw.ai/cat