### PR TITLE
Fix hover flicker on homepage cards and buttons

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2115,7 +2115,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       height: 80px;
     }
 
-    .cta {
+    .cta-surface {
       padding: 20px 12px;
     }
 
@@ -2141,6 +2141,9 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     .testimonial-card {
       min-width: 280px;
       max-width: 320px;
+    }
+
+    .testimonial-card-surface {
       padding: 12px;
     }
 
@@ -2214,7 +2217,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       gap: 6px;
     }
 
-    .macos-download-btn {
+    .macos-download-btn-surface {
       padding: 12px 20px;
       font-size: 0.9rem;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -116,16 +116,18 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
         <div class="testimonials-row row-1" style={`--duration: ${duration1}s`}>
           {row1.map((t) => (
             <a href={t.url} target="_blank" rel="noopener" class="testimonial-card" tabindex="-1">
-              <img
-                src={`https://unavatar.io/x/${t.author}`}
-                alt={t.author}
-                class="testimonial-avatar"
-                loading="lazy"
-                onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=88'`}
-              />
-              <div class="testimonial-content">
-                <p class="testimonial-quote">"{t.quote}"</p>
-                <span class="testimonial-author">@{t.author}</span>
+              <div class="testimonial-card-surface">
+                <img
+                  src={`https://unavatar.io/x/${t.author}`}
+                  alt={t.author}
+                  class="testimonial-avatar"
+                  loading="lazy"
+                  onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=88'`}
+                />
+                <div class="testimonial-content">
+                  <p class="testimonial-quote">"{t.quote}"</p>
+                  <span class="testimonial-author">@{t.author}</span>
+                </div>
               </div>
             </a>
           ))}
@@ -133,16 +135,18 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
         <div class="testimonials-row row-2" style={`--duration: ${duration2}s`}>
           {row2.map((t) => (
             <a href={t.url} target="_blank" rel="noopener" class="testimonial-card">
-              <img
-                src={`https://unavatar.io/x/${t.author}`}
-                alt={t.author}
-                class="testimonial-avatar"
-                loading="lazy"
-                onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=88'`}
-              />
-              <div class="testimonial-content">
-                <p class="testimonial-quote">"{t.quote}"</p>
-                <span class="testimonial-author">@{t.author}</span>
+              <div class="testimonial-card-surface">
+                <img
+                  src={`https://unavatar.io/x/${t.author}`}
+                  alt={t.author}
+                  class="testimonial-avatar"
+                  loading="lazy"
+                  onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=88'`}
+                />
+                <div class="testimonial-content">
+                  <p class="testimonial-quote">"{t.quote}"</p>
+                  <span class="testimonial-author">@{t.author}</span>
+                </div>
               </div>
             </a>
           ))}
@@ -263,12 +267,14 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
               <span class="macos-subtitle">Menubar access to your lobster. Works great alongside the CLI.</span>
             </div>
             <a href="https://github.com/openclaw/openclaw/releases/latest" class="macos-download-btn" target="_blank" rel="noopener">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                <polyline points="7 10 12 15 17 10"/>
-                <line x1="12" y1="15" x2="12" y2="3"/>
-              </svg>
-              Download for macOS
+              <span class="macos-download-btn-surface">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                  <polyline points="7 10 12 15 17 10"/>
+                  <line x1="12" y1="15" x2="12" y2="3"/>
+                </svg>
+                Download for macOS
+              </span>
             </a>
             <span class="macos-meta">Requires macOS 15+ · Universal Binary</span>
           </div>
@@ -563,34 +569,46 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       <SectionHeader title="What It Does" />
       <div class="features-grid">
         <a href="https://docs.openclaw.ai/getting-started" target="_blank" rel="noopener" class="feature-card">
-          <div class="feature-icon"><Icon icon="lucide:home" color="var(--coral-bright)" size={28} /></div>
-          <h3 class="feature-title">Runs on Your Machine</h3>
-          <p class="feature-desc">Mac, Windows, or Linux. Anthropic, OpenAI, or local models. Private by default—your data stays yours.</p>
+          <div class="feature-card-surface">
+            <div class="feature-icon"><Icon icon="lucide:home" color="var(--coral-bright)" size={28} /></div>
+            <h3 class="feature-title">Runs on Your Machine</h3>
+            <p class="feature-desc">Mac, Windows, or Linux. Anthropic, OpenAI, or local models. Private by default—your data stays yours.</p>
+          </div>
         </a>
         <a href="/integrations" class="feature-card">
-          <div class="feature-icon"><Icon icon="lucide:message-circle" color="var(--coral-bright)" size={28} /></div>
-          <h3 class="feature-title">Any Chat App</h3>
-          <p class="feature-desc">Talk to it on WhatsApp, Telegram, Discord, Slack, Signal, or iMessage. Works in DMs and group chats.</p>
+          <div class="feature-card-surface">
+            <div class="feature-icon"><Icon icon="lucide:message-circle" color="var(--coral-bright)" size={28} /></div>
+            <h3 class="feature-title">Any Chat App</h3>
+            <p class="feature-desc">Talk to it on WhatsApp, Telegram, Discord, Slack, Signal, or iMessage. Works in DMs and group chats.</p>
+          </div>
         </a>
         <a href="https://docs.openclaw.ai/session" target="_blank" rel="noopener" class="feature-card">
-          <div class="feature-icon"><Icon icon="lucide:brain" color="var(--coral-bright)" size={28} /></div>
-          <h3 class="feature-title">Persistent Memory</h3>
-          <p class="feature-desc">Remembers you and becomes uniquely yours. Your preferences, your context, your AI.</p>
+          <div class="feature-card-surface">
+            <div class="feature-icon"><Icon icon="lucide:brain" color="var(--coral-bright)" size={28} /></div>
+            <h3 class="feature-title">Persistent Memory</h3>
+            <p class="feature-desc">Remembers you and becomes uniquely yours. Your preferences, your context, your AI.</p>
+          </div>
         </a>
         <a href="https://docs.openclaw.ai/browser" target="_blank" rel="noopener" class="feature-card">
-          <div class="feature-icon"><Icon icon="lucide:globe" color="var(--coral-bright)" size={28} /></div>
-          <h3 class="feature-title">Browser Control</h3>
-          <p class="feature-desc">It can browse the web, fill forms, and extract data from any site.</p>
+          <div class="feature-card-surface">
+            <div class="feature-icon"><Icon icon="lucide:globe" color="var(--coral-bright)" size={28} /></div>
+            <h3 class="feature-title">Browser Control</h3>
+            <p class="feature-desc">It can browse the web, fill forms, and extract data from any site.</p>
+          </div>
         </a>
         <a href="https://docs.openclaw.ai/bash" target="_blank" rel="noopener" class="feature-card">
-          <div class="feature-icon"><Icon icon="lucide:terminal" color="var(--coral-bright)" size={28} /></div>
-          <h3 class="feature-title">Full System Access</h3>
-          <p class="feature-desc">Read and write files, run shell commands, execute scripts. Full access or sandboxed—your choice.</p>
+          <div class="feature-card-surface">
+            <div class="feature-icon"><Icon icon="lucide:terminal" color="var(--coral-bright)" size={28} /></div>
+            <h3 class="feature-title">Full System Access</h3>
+            <p class="feature-desc">Read and write files, run shell commands, execute scripts. Full access or sandboxed—your choice.</p>
+          </div>
         </a>
         <a href="https://docs.openclaw.ai/skills" target="_blank" rel="noopener" class="feature-card">
-          <div class="feature-icon"><Icon icon="lucide:puzzle" color="var(--coral-bright)" size={28} /></div>
-          <h3 class="feature-title">Skills & Plugins</h3>
-          <p class="feature-desc">Extend with community skills or build your own. It can even write its own.</p>
+          <div class="feature-card-surface">
+            <div class="feature-icon"><Icon icon="lucide:puzzle" color="var(--coral-bright)" size={28} /></div>
+            <h3 class="feature-title">Skills & Plugins</h3>
+            <p class="feature-desc">Extend with community skills or build your own. It can even write its own.</p>
+          </div>
         </a>
       </div>
     </section>
@@ -601,8 +619,10 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       <div class="integrations-row">
         {integrationPills.map((p) => (
           <span class="integration-pill">
-            <Icon icon={p.icon} color={p.color} size={16} />
-            <span>{p.name}</span>
+            <span class="integration-pill-surface">
+              <Icon icon={p.icon} color={p.color} size={16} />
+              <span>{p.name}</span>
+            </span>
           </span>
         ))}
       </div>
@@ -618,28 +638,32 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       <SectionHeader title="Featured In" />
       <div class="press-grid">
         <a href="https://www.macstories.net/stories/clawdbot-showed-me-what-the-future-of-personal-ai-assistants-looks-like/" target="_blank" rel="noopener" class="press-card press-featured">
-          <div class="press-logo">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="press-icon">
-              <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-            </svg>
-            <span class="press-name">MacStories</span>
+          <div class="press-card-surface">
+            <div class="press-logo">
+              <svg viewBox="0 0 24 24" fill="currentColor" class="press-icon">
+                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
+              </svg>
+              <span class="press-name">MacStories</span>
+            </div>
+            <blockquote class="press-quote">
+              "OpenClaw Showed Me What the Future of Personal AI Assistants Looks Like"
+            </blockquote>
+            <span class="press-author">Federico Viticci</span>
           </div>
-          <blockquote class="press-quote">
-            "OpenClaw Showed Me What the Future of Personal AI Assistants Looks Like"
-          </blockquote>
-          <span class="press-author">Federico Viticci</span>
         </a>
         <a href="https://www.starryhope.com/minipcs/clawdbot-mac-mini-ai-agent-trend/" target="_blank" rel="noopener" class="press-card">
-          <div class="press-logo">
-            <svg viewBox="0 0 24 24" fill="currentColor" class="press-icon">
-              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
-            </svg>
-            <span class="press-name">StarryHope</span>
+          <div class="press-card-surface">
+            <div class="press-logo">
+              <svg viewBox="0 0 24 24" fill="currentColor" class="press-icon">
+                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+              </svg>
+              <span class="press-name">StarryHope</span>
+            </div>
+            <blockquote class="press-quote">
+              "The Lobster Takeover: Why Developers Are Buying Mac Minis to Run Their Own AI Agents"
+            </blockquote>
+            <span class="press-author">Jim Mendenhall</span>
           </div>
-          <blockquote class="press-quote">
-            "The Lobster Takeover: Why Developers Are Buying Mac Minis to Run Their Own AI Agents"
-          </blockquote>
-          <span class="press-author">Jim Mendenhall</span>
         </a>
       </div>
     </section>
@@ -647,38 +671,46 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     <!-- CTA Grid -->
     <nav class="cta-grid">
       <a href="https://discord.com/invite/clawd" class="cta cta-discord" target="_blank" rel="noopener">
-        <svg class="cta-icon" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
-        </svg>
-        <span class="cta-label">Discord</span>
-        <span class="cta-sub">Join the community</span>
+        <span class="cta-surface">
+          <svg class="cta-icon" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+          </svg>
+          <span class="cta-label">Discord</span>
+          <span class="cta-sub">Join the community</span>
+        </span>
       </a>
 
       <a href="https://docs.openclaw.ai/getting-started" class="cta cta-docs" target="_blank" rel="noopener">
-        <svg class="cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-          <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-          <line x1="8" y1="7" x2="16" y2="7"/>
-          <line x1="8" y1="11" x2="14" y2="11"/>
-        </svg>
-        <span class="cta-label">Documentation</span>
-        <span class="cta-sub">Learn the ropes</span>
+        <span class="cta-surface">
+          <svg class="cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+            <line x1="8" y1="7" x2="16" y2="7"/>
+            <line x1="8" y1="11" x2="14" y2="11"/>
+          </svg>
+          <span class="cta-label">Documentation</span>
+          <span class="cta-sub">Learn the ropes</span>
+        </span>
       </a>
 
       <a href="https://github.com/openclaw/openclaw" class="cta cta-github" target="_blank" rel="noopener">
-        <svg class="cta-icon" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-        </svg>
-        <span class="cta-label">GitHub</span>
-        <span class="cta-sub">View the source</span>
+        <span class="cta-surface">
+          <svg class="cta-icon" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+          </svg>
+          <span class="cta-label">GitHub</span>
+          <span class="cta-sub">View the source</span>
+        </span>
       </a>
 
       <a href="https://clawhub.ai" class="cta cta-skills" target="_blank" rel="noopener">
-        <svg class="cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
-        </svg>
-        <span class="cta-label">ClawHub</span>
-        <span class="cta-sub">Download skills</span>
+        <span class="cta-surface">
+          <svg class="cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+          </svg>
+          <span class="cta-label">ClawHub</span>
+          <span class="cta-sub">Download skills</span>
+        </span>
       </a>
     </nav>
 
@@ -700,11 +732,13 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
             aria-label="Email address"
           />
           <button type="submit" class="newsletter-btn">
-            Subscribe
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="5" y1="12" x2="19" y2="12"/>
-              <polyline points="12 5 19 12 12 19"/>
-            </svg>
+            <span class="newsletter-btn-surface">
+              Subscribe
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="5" y1="12" x2="19" y2="12"/>
+                <polyline points="12 5 19 12 12 19"/>
+              </svg>
+            </span>
           </button>
         </form>
       </div>
@@ -717,17 +751,25 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       </h2>
       <div class="sponsors-grid">
         <a href="https://openai.com" target="_blank" rel="noopener" class="sponsor-card">
-          <img src="/sponsors/openai.svg" alt="OpenAI" class="sponsor-logo sponsor-logo-openai sponsor-logo-invert-on-light" loading="lazy" />
+          <span class="sponsor-card-surface">
+            <img src="/sponsors/openai.svg" alt="OpenAI" class="sponsor-logo sponsor-logo-openai sponsor-logo-invert-on-light" loading="lazy" />
+          </span>
         </a>
         <a href="https://vercel.com" target="_blank" rel="noopener" class="sponsor-card">
-          <img src="/sponsors/vercel-dark.svg" alt="Vercel" class="sponsor-logo sponsor-logo-vercel sponsor-logo-dark-only" loading="lazy" />
-          <img src="/sponsors/vercel-light.svg" alt="Vercel" class="sponsor-logo sponsor-logo-vercel sponsor-logo-light-only" loading="lazy" />
+          <span class="sponsor-card-surface">
+            <img src="/sponsors/vercel-dark.svg" alt="Vercel" class="sponsor-logo sponsor-logo-vercel sponsor-logo-dark-only" loading="lazy" />
+            <img src="/sponsors/vercel-light.svg" alt="Vercel" class="sponsor-logo sponsor-logo-vercel sponsor-logo-light-only" loading="lazy" />
+          </span>
         </a>
         <a href="https://blacksmith.sh" target="_blank" rel="noopener" class="sponsor-card">
-          <img src="/sponsors/blacksmith.svg" alt="Blacksmith" class="sponsor-logo sponsor-logo-blacksmith sponsor-logo-invert-on-light" loading="lazy" />
+          <span class="sponsor-card-surface">
+            <img src="/sponsors/blacksmith.svg" alt="Blacksmith" class="sponsor-logo sponsor-logo-blacksmith sponsor-logo-invert-on-light" loading="lazy" />
+          </span>
         </a>
         <a href="https://www.convex.dev" target="_blank" rel="noopener" class="sponsor-card">
-          <img src="/sponsors/convex.svg" alt="Convex" class="sponsor-logo sponsor-logo-convex sponsor-logo-invert-on-light" loading="lazy" />
+          <span class="sponsor-card-surface">
+            <img src="/sponsors/convex.svg" alt="Convex" class="sponsor-logo sponsor-logo-convex sponsor-logo-invert-on-light" loading="lazy" />
+          </span>
         </a>
       </div>
     </section>
@@ -954,23 +996,82 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     }
   }
 
+  .cta,
+  .feature-card,
+  .integration-pill,
+  .macos-download-btn,
+  .newsletter-btn,
+  .press-card,
+  .sponsor-card,
+  .testimonial-card {
+    position: relative;
+  }
+
+  .cta,
+  .feature-card,
+  .integration-pill,
+  .press-card,
+  .sponsor-card {
+    --lift-distance: 4px;
+  }
+
+  .macos-download-btn,
+  .newsletter-btn,
+  .testimonial-card {
+    --lift-distance: 2px;
+  }
+
+  .cta::before,
+  .feature-card::before,
+  .integration-pill::before,
+  .macos-download-btn::before,
+  .newsletter-btn::before,
+  .press-card::before,
+  .sponsor-card::before,
+  .testimonial-card::before {
+    content: '';
+    position: absolute;
+    top: calc(var(--lift-distance) * -1);
+    left: 0;
+    right: 0;
+    height: var(--lift-distance);
+  }
+
+  .cta-surface,
+  .feature-card-surface,
+  .integration-pill-surface,
+  .macos-download-btn-surface,
+  .newsletter-btn-surface,
+  .press-card-surface,
+  .sponsor-card-surface,
+  .testimonial-card-surface {
+    transition:
+      transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
   .cta {
+    display: block;
+    text-decoration: none;
+    color: var(--text-primary);
+  }
+
+  .cta-surface {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
+    height: 100%;
     padding: 24px 16px;
     border-radius: 16px;
     border: 1px solid var(--border-subtle);
     background: var(--surface-card);
     backdrop-filter: blur(12px);
-    text-decoration: none;
-    color: var(--text-primary);
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  .cta:hover {
-    transform: translateY(-4px);
+  .cta:hover .cta-surface {
+    transform: translateY(calc(var(--lift-distance) * -1));
     border-color: var(--border-accent);
     box-shadow:
       0 12px 40px var(--shadow-coral-soft),
@@ -988,16 +1089,16 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     transform: scale(1.1);
   }
 
-  .cta-discord:hover { border-color: #5865F2; box-shadow: 0 12px 40px rgba(88, 101, 242, 0.2); }
+  .cta-discord:hover .cta-surface { border-color: #5865F2; box-shadow: 0 12px 40px rgba(88, 101, 242, 0.2); }
   .cta-discord:hover .cta-icon { color: #5865F2; }
 
-  .cta-docs:hover { border-color: var(--cyan-bright); box-shadow: 0 12px 40px var(--shadow-cyan-soft); }
+  .cta-docs:hover .cta-surface { border-color: var(--cyan-bright); box-shadow: 0 12px 40px var(--shadow-cyan-soft); }
   .cta-docs:hover .cta-icon { color: var(--cyan-bright); }
 
-  .cta-github:hover { border-color: var(--github-hover-color); box-shadow: 0 12px 40px var(--shadow-github-soft); }
+  .cta-github:hover .cta-surface { border-color: var(--github-hover-color); box-shadow: 0 12px 40px var(--shadow-github-soft); }
   .cta-github:hover .cta-icon { color: var(--github-hover-color); }
 
-  .cta-skills:hover { border-color: #fbbf24; box-shadow: 0 12px 40px rgba(251, 191, 36, 0.15); }
+  .cta-skills:hover .cta-surface { border-color: #fbbf24; box-shadow: 0 12px 40px rgba(251, 191, 36, 0.15); }
   .cta-skills:hover .cta-icon { color: #fbbf24; }
 
   .cta-label {
@@ -1082,27 +1183,32 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
 
   .newsletter-btn {
     display: inline-flex;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
+
+  .newsletter-btn-surface {
+    display: inline-flex;
     align-items: center;
     gap: 8px;
     padding: 14px 24px;
     border-radius: 12px;
-    border: none;
     background: linear-gradient(135deg, var(--coral-bright) 0%, var(--coral-dark) 100%);
     color: white;
     font-family: var(--font-display);
     font-size: 0.95rem;
     font-weight: 600;
-    cursor: pointer;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     box-shadow: 0 4px 20px var(--shadow-coral-mid);
   }
 
-  .newsletter-btn:hover {
-    transform: translateY(-2px);
+  .newsletter-btn:hover .newsletter-btn-surface {
+    transform: translateY(calc(var(--lift-distance) * -1));
     box-shadow: 0 8px 30px var(--shadow-coral-strong);
   }
 
-  .newsletter-btn:active {
+  .newsletter-btn:active .newsletter-btn-surface {
     transform: translateY(0);
   }
 
@@ -1133,6 +1239,11 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       width: 100%;
       justify-content: center;
     }
+
+    .newsletter-btn-surface {
+      width: 100%;
+      justify-content: center;
+    }
   }
 
   /* Features */
@@ -1155,19 +1266,22 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
 
   .feature-card {
     display: block;
-    padding: 20px;
-    border-radius: 14px;
-    border: 1px solid var(--border-subtle);
-    background: var(--surface-card);
-    backdrop-filter: blur(12px);
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     text-decoration: none;
     color: inherit;
     cursor: pointer;
   }
 
-  .feature-card:hover {
-    transform: translateY(-4px);
+  .feature-card-surface {
+    height: 100%;
+    padding: 20px;
+    border-radius: 14px;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-card);
+    backdrop-filter: blur(12px);
+  }
+
+  .feature-card:hover .feature-card-surface {
+    transform: translateY(calc(var(--lift-distance) * -1));
     border-color: var(--coral-bright);
     box-shadow: 0 12px 40px color-mix(in srgb, var(--coral-bright) 20%, transparent);
   }
@@ -1215,16 +1329,6 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
 
   .integration-pill {
     display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 8px 14px;
-    border-radius: 20px;
-    border: 1px solid var(--border-subtle);
-    background: var(--surface-card);
-    backdrop-filter: blur(8px);
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     cursor: default;
   }
 
@@ -1235,9 +1339,22 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     transition: all 0.2s ease;
   }
 
-  .integration-pill:hover {
+  .integration-pill-surface {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 14px;
+    border-radius: 20px;
+    border: 1px solid var(--border-subtle);
+    background: var(--surface-card);
+    backdrop-filter: blur(8px);
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  .integration-pill:hover .integration-pill-surface {
     border-color: var(--coral-bright);
-    transform: translateY(-4px);
+    transform: translateY(calc(var(--lift-distance) * -1));
     box-shadow: 0 8px 24px color-mix(in srgb, var(--coral-bright) 20%, transparent);
   }
 
@@ -1286,23 +1403,27 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
   }
 
   .press-card {
+    display: block;
+    text-decoration: none;
+    color: var(--text-primary);
+    text-align: center;
+  }
+
+  .press-card-surface {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 16px;
+    height: 100%;
     padding: 24px 28px;
     border-radius: 16px;
     border: 1px solid var(--border-subtle);
     background: var(--surface-card-strong);
     backdrop-filter: blur(12px);
-    text-decoration: none;
-    color: var(--text-primary);
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    text-align: center;
   }
 
-  .press-card:hover {
-    transform: translateY(-4px);
+  .press-card:hover .press-card-surface {
+    transform: translateY(calc(var(--lift-distance) * -1));
     border-color: var(--coral-bright);
     box-shadow: 0 12px 40px var(--shadow-coral-soft);
   }
@@ -1343,7 +1464,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     font-weight: 500;
   }
 
-  .press-featured {
+  .press-featured .press-card-surface {
     border-color: var(--border-accent);
     background: var(--press-featured-gradient);
   }
@@ -1613,24 +1734,29 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
 
   .macos-download-btn {
     display: inline-flex;
+    padding: 0;
+    background: none;
+    border: none;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .macos-download-btn-surface {
+    display: inline-flex;
     align-items: center;
     gap: 10px;
     padding: 14px 28px;
     background: linear-gradient(135deg, var(--coral-bright) 0%, var(--coral-dark) 100%);
-    border: none;
     border-radius: 12px;
     color: white;
     font-family: var(--font-display);
     font-size: 1rem;
     font-weight: 600;
-    text-decoration: none;
-    cursor: pointer;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     box-shadow: 0 4px 20px var(--shadow-coral-mid);
   }
 
-  .macos-download-btn:hover {
-    transform: translateY(-2px);
+  .macos-download-btn:hover .macos-download-btn-surface {
+    transform: translateY(calc(var(--lift-distance) * -1));
     box-shadow: 0 8px 30px var(--shadow-coral-strong);
   }
 
@@ -1663,6 +1789,11 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
   }
 
   .sponsor-card {
+    display: block;
+    text-decoration: none;
+  }
+
+  .sponsor-card-surface {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -1671,12 +1802,10 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
     border: 1px solid var(--border-subtle);
     background: var(--surface-card);
     backdrop-filter: blur(12px);
-    text-decoration: none;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  .sponsor-card:hover {
-    transform: translateY(-4px);
+  .sponsor-card:hover .sponsor-card-surface {
+    transform: translateY(calc(var(--lift-distance) * -1));
     border-color: var(--border-accent);
     box-shadow: 0 12px 40px var(--shadow-coral-soft);
   }
@@ -1730,7 +1859,7 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
       gap: 16px;
     }
 
-    .sponsor-card {
+    .sponsor-card-surface {
       padding: 16px 24px;
     }
 
@@ -1914,25 +2043,28 @@ const duration2 = (row2.length / 2 * pixelsPerItem) / pixelsPerSecond;
   }
 
   .testimonial-card {
+    display: block;
+    min-width: 320px;
+    max-width: 400px;
+    text-decoration: none;
+    color: var(--text-primary);
+    flex-shrink: 0;
+  }
+
+  .testimonial-card-surface {
     display: flex;
     align-items: flex-start;
     gap: 12px;
     padding: 16px;
-    min-width: 320px;
-    max-width: 400px;
     border-radius: 12px;
     border: 1px solid var(--border-subtle);
     background: var(--surface-card-strong);
     backdrop-filter: blur(8px);
-    text-decoration: none;
-    color: var(--text-primary);
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-    flex-shrink: 0;
   }
 
-  .testimonial-card:hover {
+  .testimonial-card:hover .testimonial-card-surface {
     border-color: var(--coral-bright);
-    transform: translateY(-2px);
+    transform: translateY(calc(var(--lift-distance) * -1));
     box-shadow: 0 8px 24px var(--shadow-coral-soft);
   }
 


### PR DESCRIPTION
## Summary

This PR fixes hover flicker on interactive cards and buttons on the homepage.

The issue happened because the hovered element itself was moved with `translateY(...)`, which could cause the cursor to briefly leave and re-enter the hover area near the edges.

## What changed

- kept the outer interactive element stationary
- moved the lift animation to an inner surface element
- added a small top hover buffer to keep hover stable while the surface is lifted
- applied the fix to homepage cards and buttons that use the lift-on-hover effect

## Result

- preserves the existing hover animation
- removes the visible flicker when hovering near card/button edges

## Testing

- manually tested homepage hover interactions
- `bun run build`