### PR TITLE
fix: align install-cli package root with update semantics

### DIFF
--- a/public/install-cli.sh
+++ b/public/install-cli.sh
@@ -475,21 +475,22 @@ install_openclaw() {
   fi
 
   if [[ "${requested}" == "latest" ]]; then
-    if ! SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$PREFIX" "${npm_args[@]}" "openclaw@latest"; then
+    if ! SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@latest"; then
       log "npm install openclaw@latest failed; retrying openclaw@next"
       emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"retry\",\"version\":\"next\"}"
-      SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$PREFIX" "${npm_args[@]}" "openclaw@next"
+      SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@next"
       requested="next"
     fi
   else
-    SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$PREFIX" "${npm_args[@]}" "openclaw@${requested}"
+    SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@${requested}"
   fi
 
+  mkdir -p "${PREFIX}/bin"
   rm -f "${PREFIX}/bin/openclaw"
   cat > "${PREFIX}/bin/openclaw" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-exec "${PREFIX}/tools/node/bin/node" "${PREFIX}/lib/node_modules/openclaw/dist/entry.js" "\$@"
+exec "${PREFIX}/tools/node/bin/node" "$(node_dir)/lib/node_modules/openclaw/dist/entry.js" "\$@"
 EOF
   chmod +x "${PREFIX}/bin/openclaw"
   emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"ok\",\"version\":\"${requested}\"}"

--- a/scripts/test-install-cli-unit.sh
+++ b/scripts/test-install-cli-unit.sh
@@ -131,6 +131,51 @@ EOF
   assert_eq "$package_count" "1" "ensure_pnpm_git_prepare_allowlist package count"
 )
 
+echo "==> case: install_openclaw keeps a single package root under toolchain"
+(
+  root="${TMP_DIR}/case-install-npm"
+  prefix="${root}/prefix"
+  fake_bin="${root}/bin"
+  fake_npm="${fake_bin}/npm"
+  toolchain_dir="${prefix}/tools/node-v${NODE_VERSION}"
+  entry_js="${toolchain_dir}/lib/node_modules/openclaw/dist/entry.js"
+  mkdir -p "${fake_bin}" "${toolchain_dir}/bin" "$(dirname "${entry_js}")"
+  printf 'console.log("ok")\n' > "${entry_js}"
+  printf 'legacy-bin\n' > "${toolchain_dir}/bin/openclaw"
+
+  cat >"${fake_npm}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "${FAKE_NPM_ARGS_FILE}"
+EOF
+  chmod +x "${fake_npm}"
+
+  export PREFIX="${prefix}"
+  export FAKE_NPM_ARGS_FILE="${root}/npm-args.txt"
+  export SHARP_IGNORE_GLOBAL_LIBVIPS=1
+  export OPENCLAW_VERSION=latest
+  export NPM_LOGLEVEL=error
+
+  npm_bin() { echo "${fake_npm}"; }
+  log() { :; }
+  emit_json() { :; }
+  fix_npm_prefix_if_needed() { :; }
+
+  install_openclaw
+
+  args="$(cat "${FAKE_NPM_ARGS_FILE}")"
+  assert_eq "$args" "install -g --prefix ${toolchain_dir} --loglevel error --no-fund --no-audit openclaw@latest" "install_openclaw npm prefix"
+  test -x "${prefix}/bin/openclaw"
+  test -e "${toolchain_dir}/bin/openclaw"
+  wrapper_target="$(python3 - <<'PY' "${prefix}/bin/openclaw"
+import pathlib
+import sys
+print(pathlib.Path(sys.argv[1]).read_text().splitlines()[-1])
+PY
+)"
+  assert_eq "$wrapper_target" "exec \"${prefix}/tools/node/bin/node\" \"${toolchain_dir}/lib/node_modules/openclaw/dist/entry.js\" \"\$@\"" "install_openclaw wrapper target"
+)
+
 echo "==> case: install_openclaw_from_git uses run_pnpm"
 (
   root="${TMP_DIR}/case-install-git"


### PR DESCRIPTION
## Summary
- install the npm-managed openclaw package under the toolchain node prefix so `install-cli.sh` and `openclaw update` stop creating separate package roots
- keep `${PREFIX}/bin/openclaw` as the stable launcher for now, but point it at the toolchain package root created by the npm install
- add a focused unit test covering the npm install prefix and wrapper target

## Notes
- This is intended as a tactical fix for openclaw/openclaw.ai#116, not a final cleanup of the installer entrypoint model
- It fixes the dual-root drift by aligning the package root with `openclaw update`, but it does not try to redesign the broader wrapper / entrypoint contract
- The clean long-term direction is likely to make `$(node_dir)/bin/openclaw` the canonical wrapper and stop maintaining `${PREFIX}/bin/openclaw` as a separate stable launcher

## Test plan
- [x] Run `bash scripts/test-install-cli-unit.sh`
- [x] Reproduce the installer flow manually on a clean `~/.openclaw`
- [x] Verify `openclaw update --dry-run` and `openclaw update` stay on a single package root after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)