### PR TITLE
fix: encode author names in onerror fallback to prevent XSS

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -125,7 +125,7 @@ const featuredPress = pressArticles.slice(0, 4);
                 alt={t.author}
                 class="testimonial-avatar"
                 loading="lazy"
-                onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=88'`}
+                onerror={`this.src='https://ui-avatars.com/api/?name=${encodeURIComponent(t.author)}&background=FF4D4D&color=fff&size=88'`}
               />
               <div class="testimonial-content">
                 <p class="testimonial-quote">"{t.quote}"</p>
@@ -142,7 +142,7 @@ const featuredPress = pressArticles.slice(0, 4);
                 alt={t.author}
                 class="testimonial-avatar"
                 loading="lazy"
-                onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=88'`}
+                onerror={`this.src='https://ui-avatars.com/api/?name=${encodeURIComponent(t.author)}&background=FF4D4D&color=fff&size=88'`}
               />
               <div class="testimonial-content">
                 <p class="testimonial-quote">"{t.quote}"</p>

--- a/src/pages/shoutouts.astro
+++ b/src/pages/shoutouts.astro
@@ -28,7 +28,7 @@ const allTestimonials = [...testimonials, ...extraTestimonials];
             alt={t.author}
             class="shoutout-avatar"
             loading="lazy"
-            onerror={`this.src='https://ui-avatars.com/api/?name=${t.author}&background=FF4D4D&color=fff&size=96'`}
+            onerror={`this.src='https://ui-avatars.com/api/?name=${encodeURIComponent(t.author)}&background=FF4D4D&color=fff&size=96'`}
           />
           <div class="shoutout-content">
             <p class="shoutout-quote">"{t.quote}"</p>


### PR DESCRIPTION
## Problem

The `onerror` handlers on testimonial avatar `<img>` elements in `index.astro` and `shoutouts.astro` interpolate `t.author` directly into a JavaScript string literal:

```html
onerror="this.src='https://ui-avatars.com/api/?name=${t.author}&...'"
```

Astro HTML-encodes the attribute value, but browsers decode HTML entities before executing `onerror` JavaScript. An author name containing a single quote (e.g. `O'Malley`) produces a string literal breakout that enables arbitrary script execution.

The testimonial data comes from contributor-submitted JSON files (`testimonials.json`, `testimonials-extra.json`), making this a supply-chain XSS vector.

## Fix

Apply `encodeURIComponent()` to `t.author` at build time. This percent-encodes special characters, which both prevents the JS string breakout and properly URL-encodes the `name` parameter for the ui-avatars.com API.

## Changes

- `src/pages/index.astro`: 2 `onerror` handlers (row1 and row2 testimonial carousels)
- `src/pages/shoutouts.astro`: 1 `onerror` handler

## Verification

- `astro build` passes with no errors
- Output HTML confirmed: author names are now percent-encoded in the `onerror` attribute