### PR TITLE
fix: add unavatar API token to prevent rate limiting

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -29,7 +29,7 @@ const authors: Author[] = post.data.authors
     : [];
 
 function getAuthorAvatar(author: Author): string {
-  return author.avatar ?? (author.handle ? `https://unavatar.io/x/${author.handle}` : '/openclaw-logo-text-dark.png');
+  return author.avatar ?? (author.handle ? `https://unavatar.io/x/${author.handle}?token=sk_wjNATzw3FtKNhoJtrXo4hq` : '/openclaw-logo-text-dark.png');
 }
 
 function getAuthorLinks(author: Author): AuthorLink[] {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -32,7 +32,7 @@ function firstAuthor(post: (typeof posts)[number]): Author {
 }
 
 function getAuthorAvatar(author: Author): string {
-  return author.avatar ?? (author.handle ? `https://unavatar.io/x/${author.handle}` : '/openclaw-logo-text-dark.png');
+  return author.avatar ?? (author.handle ? `https://unavatar.io/x/${author.handle}?token=sk_wjNATzw3FtKNhoJtrXo4hq` : '/openclaw-logo-text-dark.png');
 }
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,7 +121,7 @@ const featuredPress = pressArticles.slice(0, 4);
           {row1.map((t) => (
             <a href={t.url} target="_blank" rel="noopener" class="testimonial-card" tabindex="-1">
               <img
-                src={`https://unavatar.io/x/${t.author}`}
+                src={`https://unavatar.io/x/${t.author}?token=sk_wjNATzw3FtKNhoJtrXo4hq`}
                 alt={t.author}
                 class="testimonial-avatar"
                 loading="lazy"
@@ -138,7 +138,7 @@ const featuredPress = pressArticles.slice(0, 4);
           {row2.map((t) => (
             <a href={t.url} target="_blank" rel="noopener" class="testimonial-card">
               <img
-                src={`https://unavatar.io/x/${t.author}`}
+                src={`https://unavatar.io/x/${t.author}?token=sk_wjNATzw3FtKNhoJtrXo4hq`}
                 alt={t.author}
                 class="testimonial-avatar"
                 loading="lazy"

--- a/src/pages/showcase.astro
+++ b/src/pages/showcase.astro
@@ -70,7 +70,7 @@ const categoryLabels: Record<string, string> = {
         <a href={`https://x.com/${item.author}/status/${item.id}`} target="_blank" rel="noopener" class="showcase-card">
           <div class="card-header">
             <img
-              src={`https://unavatar.io/x/${item.author}`}
+              src={`https://unavatar.io/x/${item.author}?token=sk_wjNATzw3FtKNhoJtrXo4hq`}
               alt={item.author}
               class="avatar"
               loading="lazy"


### PR DESCRIPTION
Hello,

First of all, thanks for using unavatar.io. I created the project 8 years ago, and I'm really happy to see the openclaw website using it.

Secondly, openclaw is using the unauthenticated unavatar free endpoint, which is limited to 50 requests per day per ip address.

In order to avoid that downgraded experience for your users, I added my [publishable](https://unavatar.io/docs#publishable-keys) key that can be embedded on the frontend, and it's limited to the openclaw.ai domain. This is totally free of charge.

I contacted @steipete about this on Twitter DM, but I'm sure he has a lot of stuff there, so I decided to go ahead and open the pull request. If you want to have control over the token, just go create an account on the site, and I'll transfer the token to you 🙂