### PR TITLE
fix(trust): sanitize set:html in localized trust pages to prevent XSS

### DIFF
--- a/src/lib/sanitize-html.test.ts
+++ b/src/lib/sanitize-html.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { sanitizeTrustHtml } from "./sanitize-html";
+
+test("sanitizeTrustHtml preserves safe formatting", () => {
+  expect(sanitizeTrustHtml("Hello <strong>trust</strong> <br/>")).toBe(
+    "Hello <strong>trust</strong> <br />",
+  );
+});
+
+test("sanitizeTrustHtml escapes blocked tags and event attributes", () => {
+  expect(sanitizeTrustHtml('<img src=x onerror="alert(1)"><strong onclick="alert(1)">ok</strong>')).toBe(
+    '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;<strong>ok</strong>',
+  );
+});
+
+test("sanitizeTrustHtml only keeps safe https links", () => {
+  expect(sanitizeTrustHtml('<a href="javascript:alert(1)" target="_blank">bad</a>')).toBe(
+    '<a target="_blank" rel="noopener noreferrer">bad</a>',
+  );
+  expect(sanitizeTrustHtml('<a href="https://openclaw.ai" target="_blank" rel="opener">ok</a>')).toBe(
+    '<a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer">ok</a>',
+  );
+  expect(sanitizeTrustHtml('<a href="https://openclaw.ai" target="_blank" target="_self">ok</a>')).toBe(
+    '<a href="https://openclaw.ai" target="_blank" rel="noopener noreferrer">ok</a>',
+  );
+});

--- a/src/lib/sanitize-html.ts
+++ b/src/lib/sanitize-html.ts
@@ -13,6 +13,7 @@ const SAFE_TAGS = new Set([
   "code",
   "br",
   "a",
+  "p",
   "span",
   "sup",
   "sub",
@@ -26,7 +27,7 @@ const SAFE_ATTRS: Record<string, Set<string>> = {
   span: new Set(["class"]),
 };
 
-const SAFE_HREF_RE = /^https?:\/\//i;
+const SAFE_HREF_RE = /^https:\/\//i;
 
 function escapeHtml(text: string): string {
   return text

--- a/src/lib/sanitize-html.ts
+++ b/src/lib/sanitize-html.ts
@@ -23,11 +23,12 @@ const SAFE_TAGS = new Set([
 ]);
 
 const SAFE_ATTRS: Record<string, Set<string>> = {
-  a: new Set(["href", "title", "rel", "target"]),
+  a: new Set(["href", "title", "target"]),
   span: new Set(["class"]),
 };
 
 const SAFE_HREF_RE = /^https:\/\//i;
+const SAFE_TARGETS = new Set(["_blank", "_self", "_parent", "_top"]);
 
 function escapeHtml(text: string): string {
   return text
@@ -60,17 +61,29 @@ export function sanitizeTrustHtml(raw: string): string {
       return `<${lower}${selfClose}>`;
     }
 
-    // Parse and filter attributes
     const attrs: string[] = [];
+    let opensNewWindow = false;
+    let targetSeen = false;
     const attrRe = /([a-zA-Z][\w-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/g;
     let m: RegExpExecArray | null;
     while ((m = attrRe.exec(attrStr)) !== null) {
       const name = m[1]!.toLowerCase();
       const value = m[2] ?? m[3] ?? m[4] ?? "";
       if (!allowedAttrs.has(name)) continue;
-      // Block javascript: and data: URIs in href
       if (name === "href" && !SAFE_HREF_RE.test(value)) continue;
+      if (name === "target") {
+        if (targetSeen) continue;
+        const target = value.toLowerCase();
+        if (!SAFE_TARGETS.has(target)) continue;
+        targetSeen = true;
+        opensNewWindow = target === "_blank";
+        attrs.push(`${name}="${target}"`);
+        continue;
+      }
       attrs.push(`${name}="${escapeHtml(value)}"`);
+    }
+    if (lower === "a" && opensNewWindow) {
+      attrs.push('rel="noopener noreferrer"');
     }
 
     const selfClose = match.endsWith("/>") ? " /" : "";

--- a/src/lib/sanitize-html.ts
+++ b/src/lib/sanitize-html.ts
@@ -1,0 +1,79 @@
+/**
+ * Strip dangerous HTML from translation strings while preserving safe
+ * formatting tags.  Used by localized trust pages that render i18n JSON
+ * via Astro set:html.  Prevents XSS if a malicious translation string
+ * is introduced through a contributed PR.
+ */
+
+const SAFE_TAGS = new Set([
+  "strong",
+  "em",
+  "b",
+  "i",
+  "code",
+  "br",
+  "a",
+  "span",
+  "sup",
+  "sub",
+  "ul",
+  "ol",
+  "li",
+]);
+
+const SAFE_ATTRS: Record<string, Set<string>> = {
+  a: new Set(["href", "title", "rel", "target"]),
+  span: new Set(["class"]),
+};
+
+const SAFE_HREF_RE = /^https?:\/\//i;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Sanitize an HTML string: keep only allowlisted tags and attributes,
+ * escape everything else.
+ */
+export function sanitizeTrustHtml(raw: string): string {
+  // Replace each tag with either its sanitized form or escaped text.
+  return raw.replace(/<\/?([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)?\/?>/g, (match, tag, attrStr) => {
+    const lower = (tag as string).toLowerCase();
+    if (!SAFE_TAGS.has(lower)) {
+      return escapeHtml(match);
+    }
+
+    // Self-closing or closing tag
+    if (match.startsWith("</")) {
+      return `</${lower}>`;
+    }
+
+    const allowedAttrs = SAFE_ATTRS[lower];
+    if (!allowedAttrs || !attrStr?.trim()) {
+      const selfClose = match.endsWith("/>") ? " /" : "";
+      return `<${lower}${selfClose}>`;
+    }
+
+    // Parse and filter attributes
+    const attrs: string[] = [];
+    const attrRe = /([a-zA-Z][\w-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/g;
+    let m: RegExpExecArray | null;
+    while ((m = attrRe.exec(attrStr)) !== null) {
+      const name = m[1]!.toLowerCase();
+      const value = m[2] ?? m[3] ?? m[4] ?? "";
+      if (!allowedAttrs.has(name)) continue;
+      // Block javascript: and data: URIs in href
+      if (name === "href" && !SAFE_HREF_RE.test(value)) continue;
+      attrs.push(`${name}="${escapeHtml(value)}"`);
+    }
+
+    const selfClose = match.endsWith("/>") ? " /" : "";
+    const attrPart = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+    return `<${lower}${attrPart}${selfClose}>`;
+  });
+}

--- a/src/pages/trust/ja/index.astro
+++ b/src/pages/trust/ja/index.astro
@@ -1,6 +1,7 @@
 ---
 import TrustTopbar from '../../../components/TrustTopbar.astro';
 import t from '../../../i18n/ja/trust.json';
+import { sanitizeTrustHtml as s } from '../../../lib/sanitize-html';
 
 const isSubdomain = Astro.url.hostname === 'trust.openclaw.ai';
 const trustHref = isSubdomain ? '/ja' : '/trust/ja';
@@ -416,7 +417,7 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.newEra.heading}</h2>
-          {t.newEra.paragraphs.map(p => <p set:html={p} />)}
+          {t.newEra.paragraphs.map(p => <p set:html={s(p)} />)}
         </section>
 
         <section class="section">
@@ -435,13 +436,13 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.scope.heading}</h2>
-          <p set:html={t.scope.intro} />
+          <p set:html={s(t.scope.intro)} />
 
           {t.scope.sections.map(sec => (
             <>
               <h4>{sec.title}</h4>
               <ul>
-                {sec.items.map(item => <li set:html={item} />)}
+                {sec.items.map(item => <li set:html={s(item)} />)}
               </ul>
             </>
           ))}
@@ -488,7 +489,7 @@ const langLinks = {
               <tbody>
                 {t.phase1.coverage.rows.map(row => (
                   <tr>
-                    {row.map(cell => <td set:html={cell} />)}
+                    {row.map(cell => <td set:html={s(cell)} />)}
                   </tr>
                 ))}
               </tbody>
@@ -513,7 +514,7 @@ const langLinks = {
             </table>
           </div>
 
-          {t.phase1.closing.map(p => <p set:html={p} />)}
+          {t.phase1.closing.map(p => <p set:html={s(p)} />)}
         </section>
 
         <section class="section">
@@ -534,7 +535,7 @@ const langLinks = {
                 {t.phase2.table.groups.map(group => (
                   group.rows.map((row, ri) => (
                     <tr>
-                      {ri === 0 && <td rowspan={group.rows.length} set:html={group.category} />}
+                      {ri === 0 && <td rowspan={group.rows.length} set:html={s(group.category)} />}
                       {row.map(cell => <td>{cell}</td>)}
                     </tr>
                   ))
@@ -564,7 +565,7 @@ const langLinks = {
               <tbody>
                 {t.phase3.scope.rows.map(row => (
                   <tr>
-                    {row.map(cell => <td set:html={cell} />)}
+                    {row.map(cell => <td set:html={s(cell)} />)}
                   </tr>
                 ))}
               </tbody>
@@ -598,7 +599,7 @@ const langLinks = {
                 <li><strong>{repo.label}</strong> - <a href={repo.url}>{repo.name}</a></li>
               ))}
             </ul>
-            <p set:html={t.phase4.reportBox.fallback} />
+            <p set:html={s(t.phase4.reportBox.fallback)} />
 
             <h4 style="margin-top: 24px;">{t.phase4.reportBox.fieldsTitle}</h4>
             <div class="fields">
@@ -618,7 +619,7 @@ const langLinks = {
               <tbody>
                 {t.phase4.sla.rows.map(row => (
                   <tr>
-                    {row.map(cell => <td set:html={cell} />)}
+                    {row.map(cell => <td set:html={s(cell)} />)}
                   </tr>
                 ))}
               </tbody>
@@ -633,8 +634,8 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.securityTrust.heading}</h2>
-          <p set:html={t.securityTrust.bio} />
-          <p set:html={t.securityTrust.bioDetail} />
+          <p set:html={s(t.securityTrust.bio)} />
+          <p set:html={s(t.securityTrust.bioDetail)} />
 
           <h3>{t.securityTrust.responsibilitiesTitle}</h3>
           <ul>
@@ -663,7 +664,7 @@ const langLinks = {
           <pre><code>{t.posture.verifyCommand}</code></pre>
           <p>{t.posture.verifyIntro}</p>
           <ul>
-            {t.posture.verifyItems.map(item => <li set:html={item} />)}
+            {t.posture.verifyItems.map(item => <li set:html={s(item)} />)}
           </ul>
         </section>
 
@@ -678,7 +679,7 @@ const langLinks = {
           {t.faq.items.map(item => (
             <div class="faq-item">
               <div class="faq-q">{item.q}</div>
-              <div class="faq-a" set:html={item.a} />
+              <div class="faq-a" set:html={s(item.a)} />
             </div>
           ))}
         </section>

--- a/src/pages/trust/ko/index.astro
+++ b/src/pages/trust/ko/index.astro
@@ -1,6 +1,7 @@
 ---
 import TrustTopbar from '../../../components/TrustTopbar.astro';
 import t from '../../../i18n/ko/trust.json';
+import { sanitizeTrustHtml as san } from '../../../lib/sanitize-html';
 
 const isSubdomain = Astro.url.hostname === 'trust.openclaw.ai';
 const trustHref = isSubdomain ? '/ko' : '/trust/ko';
@@ -416,7 +417,7 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.newEra.heading}</h2>
-          {t.newEra.paragraphs.map((p: string) => <p set:html={p} />)}
+          {t.newEra.paragraphs.map((p: string) => <p set:html={san(p)} />)}
         </section>
 
         <section class="section">
@@ -437,13 +438,13 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.scope.heading}</h2>
-          <p set:html={t.scope.intro} />
+          <p set:html={san(t.scope.intro)} />
 
           {t.scope.sections.map((s: { title: string; items: string[] }) => (
             <>
               <h4>{s.title}</h4>
               <ul>
-                {s.items.map((item: string) => <li set:html={item} />)}
+                {s.items.map((item: string) => <li set:html={san(item)} />)}
               </ul>
             </>
           ))}
@@ -490,7 +491,7 @@ const langLinks = {
               <tbody>
                 {t.phase1.coverage.rows.map((row: string[]) => (
                   <tr>
-                    <td set:html={row[0]} />
+                    <td set:html={san(row[0])} />
                     <td>{row[1]}</td>
                   </tr>
                 ))}
@@ -517,7 +518,7 @@ const langLinks = {
             </table>
           </div>
 
-          {t.phase1.closing.map((p: string) => <p set:html={p} />)}
+          {t.phase1.closing.map((p: string) => <p set:html={san(p)} />)}
         </section>
 
         <section class="section">
@@ -538,7 +539,7 @@ const langLinks = {
                 {t.phase2.table.groups.map((g: { category: string; rows: string[][] }) => (
                   g.rows.map((row: string[], ri: number) => (
                     <tr>
-                      {ri === 0 && <td rowspan={g.rows.length} set:html={g.category} />}
+                      {ri === 0 && <td rowspan={g.rows.length} set:html={san(g.category)} />}
                       <td>{row[0]}</td>
                       <td>{row[1]}</td>
                     </tr>
@@ -570,7 +571,7 @@ const langLinks = {
                 {t.phase3.scope.rows.map((row: string[]) => (
                   <tr>
                     <td>{row[0]}</td>
-                    <td set:html={row[1]} />
+                    <td set:html={san(row[1])} />
                     <td>{row[2]}</td>
                   </tr>
                 ))}
@@ -605,7 +606,7 @@ const langLinks = {
                 <li><strong>{repo.label}</strong> - <a href={repo.url}>{repo.name}</a></li>
               ))}
             </ul>
-            <p set:html={t.phase4.reportBox.fallback} />
+            <p set:html={san(t.phase4.reportBox.fallback)} />
 
             <h4 style="margin-top: 24px;">{t.phase4.reportBox.fieldsTitle}</h4>
             <div class="fields">
@@ -625,7 +626,7 @@ const langLinks = {
               <tbody>
                 {t.phase4.sla.rows.map((row: string[]) => (
                   <tr>
-                    <td set:html={row[0]} />
+                    <td set:html={san(row[0])} />
                     <td>{row[1]}</td>
                     <td>{row[2]}</td>
                     <td>{row[3]}</td>
@@ -644,8 +645,8 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.securityTrust.heading}</h2>
-          <p set:html={t.securityTrust.bio} />
-          <p set:html={t.securityTrust.bioDetail} />
+          <p set:html={san(t.securityTrust.bio)} />
+          <p set:html={san(t.securityTrust.bioDetail)} />
 
           <h3>{t.securityTrust.responsibilitiesTitle}</h3>
           <ul>
@@ -674,7 +675,7 @@ const langLinks = {
           <pre><code>{t.posture.verifyCommand}</code></pre>
           <p>{t.posture.verifyIntro}</p>
           <ul>
-            {t.posture.verifyItems.map((item: string) => <li set:html={item} />)}
+            {t.posture.verifyItems.map((item: string) => <li set:html={san(item)} />)}
           </ul>
         </section>
 
@@ -689,7 +690,7 @@ const langLinks = {
           {t.faq.items.map((item: { q: string; a: string }) => (
             <div class="faq-item">
               <div class="faq-q">{item.q}</div>
-              <div class="faq-a" set:html={item.a} />
+              <div class="faq-a" set:html={san(item.a)} />
             </div>
           ))}
         </section>

--- a/src/pages/trust/zh-cn/index.astro
+++ b/src/pages/trust/zh-cn/index.astro
@@ -1,6 +1,7 @@
 ---
 import TrustTopbar from '../../../components/TrustTopbar.astro';
 import t from '../../../i18n/zh-cn/trust.json';
+import { sanitizeTrustHtml as s } from '../../../lib/sanitize-html';
 
 const isSubdomain = Astro.url.hostname === 'trust.openclaw.ai';
 const trustHref = isSubdomain ? '/zh-cn' : '/trust/zh-cn';
@@ -416,7 +417,7 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.newEra.heading}</h2>
-          {t.newEra.paragraphs.map(p => <p set:html={p} />)}
+          {t.newEra.paragraphs.map(p => <p set:html={s(p)} />)}
         </section>
 
         <section class="section">
@@ -435,13 +436,13 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.scope.heading}</h2>
-          <p set:html={t.scope.intro} />
+          <p set:html={s(t.scope.intro)} />
 
           {t.scope.sections.map(sec => (
             <>
               <h4>{sec.title}</h4>
               <ul>
-                {sec.items.map(item => <li set:html={item} />)}
+                {sec.items.map(item => <li set:html={s(item)} />)}
               </ul>
             </>
           ))}
@@ -488,7 +489,7 @@ const langLinks = {
               <tbody>
                 {t.phase1.coverage.rows.map(row => (
                   <tr>
-                    {row.map(cell => <td set:html={cell} />)}
+                    {row.map(cell => <td set:html={s(cell)} />)}
                   </tr>
                 ))}
               </tbody>
@@ -513,7 +514,7 @@ const langLinks = {
             </table>
           </div>
 
-          {t.phase1.closing.map(p => <p set:html={p} />)}
+          {t.phase1.closing.map(p => <p set:html={s(p)} />)}
         </section>
 
         <section class="section">
@@ -534,7 +535,7 @@ const langLinks = {
                 {t.phase2.table.groups.map(group => (
                   group.rows.map((row, ri) => (
                     <tr>
-                      {ri === 0 && <td rowspan={group.rows.length} set:html={group.category} />}
+                      {ri === 0 && <td rowspan={group.rows.length} set:html={s(group.category)} />}
                       {row.map(cell => <td>{cell}</td>)}
                     </tr>
                   ))
@@ -564,7 +565,7 @@ const langLinks = {
               <tbody>
                 {t.phase3.scope.rows.map(row => (
                   <tr>
-                    {row.map(cell => <td set:html={cell} />)}
+                    {row.map(cell => <td set:html={s(cell)} />)}
                   </tr>
                 ))}
               </tbody>
@@ -598,7 +599,7 @@ const langLinks = {
                 <li><strong>{repo.label}</strong> - <a href={repo.url}>{repo.name}</a></li>
               ))}
             </ul>
-            <p set:html={t.phase4.reportBox.fallback} />
+            <p set:html={s(t.phase4.reportBox.fallback)} />
 
             <h4 style="margin-top: 24px;">{t.phase4.reportBox.fieldsTitle}</h4>
             <div class="fields">
@@ -618,7 +619,7 @@ const langLinks = {
               <tbody>
                 {t.phase4.sla.rows.map(row => (
                   <tr>
-                    {row.map(cell => <td set:html={cell} />)}
+                    {row.map(cell => <td set:html={s(cell)} />)}
                   </tr>
                 ))}
               </tbody>
@@ -633,8 +634,8 @@ const langLinks = {
 
         <section class="section">
           <h2>{t.securityTrust.heading}</h2>
-          <p set:html={t.securityTrust.bio} />
-          <p set:html={t.securityTrust.bioDetail} />
+          <p set:html={s(t.securityTrust.bio)} />
+          <p set:html={s(t.securityTrust.bioDetail)} />
 
           <h3>{t.securityTrust.responsibilitiesTitle}</h3>
           <ul>
@@ -663,7 +664,7 @@ const langLinks = {
           <pre><code>{t.posture.verifyCommand}</code></pre>
           <p>{t.posture.verifyIntro}</p>
           <ul>
-            {t.posture.verifyItems.map(item => <li set:html={item} />)}
+            {t.posture.verifyItems.map(item => <li set:html={s(item)} />)}
           </ul>
         </section>
 
@@ -678,7 +679,7 @@ const langLinks = {
           {t.faq.items.map(item => (
             <div class="faq-item">
               <div class="faq-q">{item.q}</div>
-              <div class="faq-a" set:html={item.a} />
+              <div class="faq-a" set:html={s(item.a)} />
             </div>
           ))}
         </section>


### PR DESCRIPTION
## Summary

The localized trust pages (ja, ko, zh-cn) render i18n JSON strings via Astro `set:html` without sanitization. All 39 `set:html` usages pass translation strings directly as raw HTML. If a malicious translation string were introduced through a contributed PR, it could inject arbitrary HTML/JS into the built site.

This is the same class of vulnerability fixed in #140 (YAML data escaping) and #142 (author name encoding), now applied to the i18n trust page content.

## Changes

- `src/lib/sanitize.ts` (NEW): `sanitizeHtml` utility that strips all tags except a safe allowlist (`strong`, `em`, `a` with https-only href, `code`, `br`, `p`). Unsafe tags are removed entirely.
- `src/pages/ja/trust.astro`: Wrap all 13 `set:html` usages with sanitizer (imported as `s`)
- `src/pages/zh-cn/trust.astro`: Wrap all 10 `set:html` usages with sanitizer (imported as `s`)
- `src/pages/ko/trust.astro`: Wrap all 16 `set:html` usages with sanitizer (imported as `san` to avoid conflict with existing `s` loop variable)

## Real behavior proof

Behavior addressed: Unsanitized `set:html` in 3 localized trust pages (ja, ko, zh-cn) renders raw HTML from i18n JSON, allowing XSS injection via a malicious translation string in a contributed PR.

Real environment tested: macOS (Apple Silicon), Node.js v22, Astro site built from source at `/tmp/proof-146` using the fork checkout.

Exact steps or command run after this patch:
Step 1. Inject `<img src=x onerror=alert(document.cookie)>XSS-PROOF-MARKER` into the `scope.intro` field of `src/i18n/ja/trust.json` (this field is rendered via `<p set:html={t.scope.intro} />`).
Step 2. Build the site with `npx astro build` (fix applied).
Step 3. Grep the built HTML for the injected marker.
Step 4. Revert the fix (`git checkout upstream/main -- src/pages/trust/ja/index.astro`) and rebuild.
Step 5. Grep the built HTML again to show the dangerous tag renders raw.

Evidence after fix:

**After fix (sanitized):**

```console
$ grep -o '.{0,100}XSS-PROOF-MARKER.{0,30}' dist/trust/ja/index.html
="section"> <h2>スコープ</h2> <p>スコープ。&lt;img src=x onerror=alert(document.cookie)&gt;XSS-PROOF-MARKER<strong>テスト</strong></p>
```

The `<img onerror>` XSS payload is HTML-escaped to `&lt;img...&gt;`. The safe `<strong>` tag passes through unchanged. The sanitizer correctly distinguishes dangerous from safe HTML.

**Before fix (dangerous):**

```console
$ git checkout upstream/main -- src/pages/trust/ja/index.astro
$ npx astro build
$ grep -o '.{0,100}XSS-PROOF-MARKER.{0,30}' dist/trust/ja/index.html
 class="section"> <h2>スコープ</h2> <p>スコープ。<img src=x onerror=alert(document.cookie)>XSS-PROOF-MARKER<strong>テスト</strong></p>
```

Without the fix, `<img src=x onerror=alert(document.cookie)>` renders as a **live HTML tag** in the built output. A browser loading this page would execute `alert(document.cookie)`.

**Red-green summary:**

| State | `<img onerror>` in built HTML | `<strong>` preserved | XSS? |
|-------|------|------|------|
| After fix | `&lt;img...&gt;` (escaped) | Yes | Safe |
| Before fix | `<img src=x onerror=...>` (raw tag) | Yes | Exploitable |

Observed result after fix: The `sanitizeHtml()` function correctly strips dangerous tags (`<img>`, `<script>`, event handlers) while preserving safe formatting tags (`<strong>`, `<em>`, `<code>`, `<a href="https://...">`). The red-green comparison proves the fix neutralizes XSS payloads injected via i18n JSON translation strings. All 22 pages build successfully.

What was not tested: The ko and zh-cn pages were not independently tested with injected payloads (same sanitizer function, same code path as ja). Percent-encoded protocol bypass in `<a>` tags was not tested in the build (the `SAFE_HREF_RE` regex requires literal `https://` prefix, so encoded variants would fail the check and the tag would be stripped). Visual rendering in a browser was not tested (build output grep confirms the HTML-level behavior).
