### PR TITLE
fix(trust): add rel noopener to external links, remove dead CNAME, align ko detailLabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Ecosystem: promote clawpdf into the TypeScript libraries section with its canonical site link.
 - Website: sanitize data-driven external links before rendering them into `href` attributes (#143, thanks @SebTardif).
+- Website: stop serving the stale GitHub Pages `CNAME` file now that Vercel owns the site, and update the hosting docs (#148, thanks @SebTardif).
 - Website: move the Discord shortcut into Vercel routing so `/discord` redirects correctly (#147, thanks @SebTardif).
 - Ecosystem: tune project card banner art visibility.
 - Ecosystem: quiet the final contribution CTA button colors.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Landing page for [OpenClaw](https://github.com/openclaw/openclaw) — your perso
 ## Tech Stack
 
 - [Astro](https://astro.build/) — Static site generator
-- GitHub Pages — Hosting
+- [Vercel](https://vercel.com/) — Hosting
 - Custom CSS — No framework, just vibes
 
 ## Development
@@ -36,7 +36,7 @@ bun run preview
 
 ## Deploy
 
-Automatically deployed to GitHub Pages on push to `main`.
+Automatically deployed to Vercel on push to `main`.
 
 ## Install Scripts
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-clawd.bot


### PR DESCRIPTION
## Summary

Current-main rewrite of the still-relevant part of the original audit cleanup.

The old trust-page hunks are obsolete because the standalone trust pages were retired on `main`. This branch now only:
- removes the stale `public/CNAME` GitHub Pages artifact that Vercel was serving as `/CNAME`
- updates README hosting/deploy wording from GitHub Pages to Vercel
- adds a maintainer changelog entry

## Proof

Before the fix, production served the stale file:

```console
$ curl -sS https://openclaw.ai/CNAME
clawd.bot
```

Local proof after the rewrite:

```console
$ bun test
4 pass, 0 fail, 14 expect() calls

$ bun run build
16 page(s) built

$ /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main
autoreview clean: no accepted/actionable findings reported
```
