### PR TITLE
fix(seo): derive canonical URL from page pathname instead of hardcoded homepage

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ interface Props {
 const {
   title,
   description = "OpenClaw — The AI that actually does things. Your personal assistant on any platform.",
-  canonicalUrl = "https://openclaw.ai/",
+  canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? "https://openclaw.ai").href,
 } = Astro.props;
 ---
 


### PR DESCRIPTION
## Summary

The `Layout.astro` default for `canonicalUrl` was hardcoded to `https://openclaw.ai/`, causing 5 pages to emit `<link rel="canonical">` and `<meta property="og:url">` pointing to the homepage instead of their own URL.

## Affected pages

| Page | Before | After |
|---|---|---|
| `/showcase` | `https://openclaw.ai/` | `https://openclaw.ai/showcase/` |
| `/shoutouts` | `https://openclaw.ai/` | `https://openclaw.ai/shoutouts/` |
| `/integrations` | `https://openclaw.ai/` | `https://openclaw.ai/integrations/` |
| `/blog` | `https://openclaw.ai/` | `https://openclaw.ai/blog/` |
| `/blog/{slug}` | `https://openclaw.ai/` | `https://openclaw.ai/blog/{slug}/` |

Pages that already passed explicit `canonicalUrl` (privacy, press) continue to work as before.

## Impact

- Google treats affected pages as duplicates of the homepage, suppressing them from search results
- Social sharing previews (X, Discord, Slack) show the homepage URL instead of the page URL

## Fix

Derive the default `canonicalUrl` from `Astro.url.pathname` combined with the configured `Astro.site`, so every page automatically gets its own canonical URL without requiring explicit overrides.

## Verification

- **Behavior addressed**: wrong canonical/og:url on 5 pages
- **Real environment tested**: local Astro build
- **Exact steps or command run after this patch**: `npx astro build && grep canonical dist/{showcase,blog,integrations,shoutouts}/index.html`
- **Evidence after fix**: showcase=`/showcase/`, blog=`/blog/`, integrations=`/integrations/`, shoutouts=`/shoutouts/`, blog posts=`/blog/{slug}/`
- **Observed result after fix**: all 5 pages now emit correct page-specific canonical and og:url
- **What was not tested**: production Vercel deployment, Google re-indexing timeline