### PR TITLE
docs: add performance and dependency cleanup post

### DIFF
--- a/src/content/blog/performance-size-supply-chain-sweep.md
+++ b/src/content/blog/performance-size-supply-chain-sweep.md
@@ -1,0 +1,208 @@
+---
+title: "OpenClaw Is Getting Faster, Smaller, and Easier to Trust"
+description: "A release sweep across February through May shows faster agent turns, fewer dependencies, and a cleaner package shape."
+date: 2026-05-28
+author: "Peter Steinberger"
+authorHandle: "steipete"
+draft: false
+tags: ["performance", "release", "security", "dependencies"]
+---
+
+OpenClaw has been getting faster and smaller at the same time. The performance work is visible in agent turns. The dependency work is quieter, but it cuts npm size, install size, audit surface, and native package surprises.
+
+The package grew while OpenClaw gained channels, providers, media, memory, and plugin SDK surface. Then we started moving heavier plugin dependency cones out of core. The full release rows and caveats live in the [technical report](https://docs.openclaw.ai/reference/release-performance-sweep).
+
+<section class="metric-grid" aria-label="OpenClaw release sweep highlights">
+  <div class="metric-card">
+    <span>Stable cold turn</span>
+    <strong>2.9x faster</strong>
+    <div class="metric-spark" aria-hidden="true">
+      <i style="--h: 100%"></i><i style="--h: 74%"></i><i style="--h: 46%"></i><i class="selected" style="--h: 34%"></i>
+    </div>
+    <p class="metric-endpoints"><span><code>v2026.4.14</code><b>9.8s</b></span><span><code>v2026.5.27</code><b>3.4s</b></span></p>
+  </div>
+  <div class="metric-card">
+    <span>Stable warm turn</span>
+    <strong>2.5x faster</strong>
+    <div class="metric-spark" aria-hidden="true">
+      <i style="--h: 100%"></i><i style="--h: 89%"></i><i style="--h: 55%"></i><i class="selected" style="--h: 40%"></i>
+    </div>
+    <p class="metric-endpoints"><span><code>v2026.4.14</code><b>7.5s</b></span><span><code>v2026.5.27</code><b>3.0s</b></span></p>
+  </div>
+  <div class="metric-card">
+    <span>Agent peak RSS</span>
+    <strong>7% lower</strong>
+    <div class="metric-spark" aria-hidden="true">
+      <i style="--h: 100%"></i><i style="--h: 95%"></i><i style="--h: 93%"></i><i class="selected" style="--h: 93%"></i>
+    </div>
+    <p class="metric-endpoints"><span><code>v2026.4.14</code><b>686 MB</b></span><span><code>v2026.5.27</code><b>635 MB</b></span></p>
+  </div>
+  <div class="metric-card">
+    <span>Published tarball</span>
+    <strong>59% smaller</strong>
+    <div class="metric-spark" aria-hidden="true">
+      <i style="--h: 30%"></i><i style="--h: 54%"></i><i style="--h: 100%"></i><i class="selected" style="--h: 41%"></i>
+    </div>
+    <p class="metric-endpoints"><span><code>2026.3.31</code><b>43.3 MB</b></span><span><code>2026.5.27</code><b>17.8 MB</b></span></p>
+  </div>
+</section>
+
+<section class="chart-grid" aria-label="OpenClaw performance, npm package, and install charts">
+  <figure class="chart-card">
+    <figcaption>Cold agent turn trend</figcaption>
+    <div class="bar-list">
+      <div class="bar-row" style="--bar: 100%">
+        <span><code>4.14</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>9.8s</strong>
+      </div>
+      <div class="bar-row" style="--bar: 74%">
+        <span><code>5.12</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>7.2s</strong>
+      </div>
+      <div class="bar-row" style="--bar: 46%">
+        <span><code>5.22</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>4.5s</strong>
+      </div>
+      <div class="bar-row selected" style="--bar: 34%">
+        <span><code>5.27</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>3.4s</strong>
+      </div>
+    </div>
+  </figure>
+
+  <figure class="chart-card">
+    <figcaption>Published tarball size</figcaption>
+    <div class="bar-list">
+      <div class="bar-row" style="--bar: 30%">
+        <span><code>1.30</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>12.8 MB</strong>
+      </div>
+      <div class="bar-row" style="--bar: 54%">
+        <span><code>2.26</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>23.6 MB</strong>
+      </div>
+      <div class="bar-row" style="--bar: 100%">
+        <span><code>3.31</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>43.3 MB</strong>
+      </div>
+      <div class="bar-row selected" style="--bar: 41%">
+        <span><code>5.27</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>17.8 MB</strong>
+      </div>
+    </div>
+  </figure>
+</section>
+
+<section class="chart-grid" aria-label="OpenClaw install footprint and plugin extraction charts">
+  <figure class="chart-card">
+    <figcaption>Fresh install footprint</figcaption>
+    <div class="bar-list">
+      <div class="bar-row" style="--bar: 57%">
+        <span><code>2.26</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>575.7 MB</strong>
+      </div>
+      <div class="bar-row" style="--bar: 33%">
+        <span><code>4.29</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>335.0 MB</strong>
+      </div>
+      <div class="bar-row danger" style="--bar: 100%">
+        <span><code>5.22*</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>1,020.6 MB</strong>
+      </div>
+      <div class="bar-row selected" style="--bar: 77%">
+        <span><code>5.27*</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>786.9 MB</strong>
+      </div>
+    </div>
+    <p class="chart-note">* Root shrinkwrap landed in 5.22; the size jump came from a bad package shape that made npm install a duplicate dependency tree.</p>
+  </figure>
+
+  <figure class="chart-card">
+    <figcaption>Installed dependency count</figcaption>
+    <div class="bar-list">
+      <div class="bar-row danger" style="--bar: 100%">
+        <span><code>2.26</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>645</strong>
+      </div>
+      <div class="bar-row" style="--bar: 68%">
+        <span><code>3.31</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>438</strong>
+      </div>
+      <div class="bar-row" style="--bar: 62%">
+        <span><code>5.22</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>401</strong>
+      </div>
+      <div class="bar-row selected" style="--bar: 58%">
+        <span><code>5.27</code></span>
+        <div class="bar-track"><div class="bar-fill"></div></div>
+        <strong>371</strong>
+      </div>
+    </div>
+    <p class="chart-note">Already down to 314 on main for the next release.</p>
+  </figure>
+</section>
+
+<section class="mini-card-grid" aria-label="Dependency cleanup highlights">
+  <div class="mini-card">
+    <span>Installed dependencies</span>
+    <strong>371</strong>
+    <p>Latest release, down 42% from the monthly high.</p>
+    <p class="muted-note">Main is already at 314.</p>
+  </div>
+  <div class="mini-card">
+    <span>Duplicate install copy</span>
+    <strong>found</strong>
+    <p>5.27 still shows the shrinkwrap-exposed duplicate tree.</p>
+    <p class="muted-note">Removed on main for the next release.</p>
+  </div>
+  <div class="mini-card">
+    <span>Shrinkwrap</span>
+    <strong>stays</strong>
+    <p><a href="https://docs.openclaw.ai/gateway/security/shrinkwrap">Shrinkwrap</a> was not the problem; the package shape was.</p>
+  </div>
+</section>
+
+<section class="timeline-list" aria-label="Release cleanup timeline">
+  <div>
+    <span>February and March</span>
+    <strong>More product, larger package</strong>
+    <p>The npm package grew from 82.9 MB unpacked to 182.6 MB unpacked while the surface area expanded.</p>
+  </div>
+  <div>
+    <span>2026.5.12</span>
+    <strong>Plugin extraction becomes visible</strong>
+    <p>Bedrock, Slack, OpenShell, Anthropic Vertex, Matrix, and WhatsApp move out of the core dependency path.</p>
+  </div>
+  <div>
+    <span>2026.5.22</span>
+    <strong>Shrinkwrap exposed bad package shape</strong>
+    <p>npm materialized a large nested tree with every canvas platform package.</p>
+  </div>
+  <div>
+    <span>2026.5.27</span>
+    <strong>Latest release: smaller package, known install debt</strong>
+    <p>17.8 MB published tarball, 371 installed dependencies, and the shrinkwrap-exposed duplicate tree still visible in fresh installs.</p>
+    <p class="muted-note">Already removed on main for the next release.</p>
+  </div>
+</section>
+
+The direction is simple: keep core small, move optional capabilities into plugins, make dependency ownership explicit, and measure the user-visible effects. Each point is one smoke run, useful for spotting large shifts rather than making fine-grained benchmark claims.
+
+For methodology, caveats, per-release rows, and the shrinkwrap boundary audit, read the [technical report](https://docs.openclaw.ai/reference/release-performance-sweep).
+
+Growth, here, looks more like molting than adding.

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -392,9 +392,24 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
   }
 
   .article-content {
+    --release-card-bg: color-mix(in srgb, var(--surface-card-strong) 84%, var(--bg-elevated));
+    --release-card-border: color-mix(in srgb, var(--text-muted) 30%, var(--border-subtle));
+    --release-card-highlight: color-mix(in srgb, var(--text-primary) 5%, transparent);
+    --release-data-ink: color-mix(in srgb, var(--cyan-bright) 58%, var(--text-primary));
+    --release-risk-ink: color-mix(in srgb, var(--coral-bright) 46%, var(--text-primary));
+    --release-track: color-mix(in srgb, var(--surface-card-strong) 72%, var(--bg-deep));
     color: var(--text-secondary);
     font-size: 1rem;
     line-height: 1.82;
+  }
+
+  :global(html[data-theme='light']) .article-content {
+    --release-card-bg: color-mix(in srgb, var(--surface-card-strong) 90%, var(--bg-elevated));
+    --release-card-border: color-mix(in srgb, var(--text-muted) 34%, var(--border-subtle));
+    --release-card-highlight: color-mix(in srgb, var(--text-primary) 4%, transparent);
+    --release-data-ink: color-mix(in srgb, var(--cyan-bright) 68%, var(--text-primary));
+    --release-risk-ink: color-mix(in srgb, var(--coral-bright) 56%, var(--text-primary));
+    --release-track: color-mix(in srgb, var(--bg-elevated) 78%, white);
   }
 
   .article-content :global(p:first-child) {
@@ -486,6 +501,278 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
     border-left: 3px solid var(--coral-bright);
     color: var(--text-primary);
     font-style: italic;
+  }
+
+  .article-content :global(.metric-grid) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+    margin: 30px 0 38px;
+  }
+
+  .article-content :global(.metric-card) {
+    border: 1px solid var(--release-card-border);
+    border-radius: 8px;
+    background:
+      linear-gradient(180deg, var(--release-card-highlight), transparent 76%),
+      var(--release-card-bg);
+    padding: 18px;
+    box-shadow: inset 0 1px 0 var(--surface-inset-highlight);
+  }
+
+  .article-content :global(.metric-card span) {
+    display: block;
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .article-content :global(.metric-card strong) {
+    display: block;
+    margin: 10px 0 8px;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: clamp(1.8rem, 4vw, 2.75rem);
+    line-height: 1;
+  }
+
+  .article-content :global(.metric-spark) {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    align-items: end;
+    gap: 6px;
+    height: 46px;
+    margin: 14px 0 12px;
+    padding: 9px;
+    border: 1px solid color-mix(in srgb, var(--text-muted) 18%, var(--border-subtle));
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--release-track) 66%, transparent);
+  }
+
+  .article-content :global(.metric-spark i) {
+    display: block;
+    height: max(5px, var(--h));
+    border-radius: 4px 4px 2px 2px;
+    background: var(--release-data-ink);
+    opacity: 0.86;
+  }
+
+  .article-content :global(.metric-spark i.selected) {
+    background: var(--release-risk-ink);
+    opacity: 1;
+  }
+
+  .article-content :global(.metric-card p) {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.55;
+  }
+
+  .article-content :global(.metric-endpoints) {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+  }
+
+  .article-content :global(.metric-endpoints span) {
+    display: grid;
+    gap: 3px;
+  }
+
+  .article-content :global(.metric-endpoints span:last-child) {
+    justify-items: end;
+    text-align: right;
+  }
+
+  .article-content :global(.metric-endpoints b) {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+  }
+
+  .article-content :global(.chart-grid) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin: 34px 0 18px;
+  }
+
+  .article-content :global(.chart-card) {
+    margin: 0;
+    border: 1px solid var(--release-card-border);
+    border-radius: 8px;
+    background:
+      linear-gradient(180deg, var(--release-card-highlight), transparent 72%),
+      var(--release-card-bg);
+    padding: 18px;
+    box-shadow: inset 0 1px 0 var(--surface-inset-highlight);
+  }
+
+  .article-content :global(.chart-card figcaption) {
+    margin: 0 0 18px;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: 1.16rem;
+    font-weight: 800;
+    line-height: 1.2;
+  }
+
+  .article-content :global(.bar-list) {
+    display: grid;
+    gap: 14px;
+  }
+
+  .article-content :global(.bar-row) {
+    display: grid;
+    grid-template-columns: minmax(118px, 0.9fr) minmax(90px, 1.2fr) minmax(64px, auto);
+    align-items: center;
+    gap: 12px;
+  }
+
+  .article-content :global(.bar-row > span) {
+    min-width: 0;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.35;
+  }
+
+  .article-content :global(.bar-row strong) {
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.86rem;
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .article-content :global(.bar-track) {
+    overflow: hidden;
+    height: 12px;
+    border: 1px solid color-mix(in srgb, var(--text-muted) 20%, var(--border-subtle));
+    border-radius: 999px;
+    background: var(--release-track);
+  }
+
+  .article-content :global(.bar-fill) {
+    width: var(--bar);
+    height: 100%;
+    border-radius: inherit;
+    background: var(--release-data-ink);
+  }
+
+  .article-content :global(.bar-row.danger .bar-fill) {
+    background: var(--release-data-ink);
+  }
+
+  .article-content :global(.bar-row.selected .bar-fill) {
+    background: var(--release-risk-ink);
+  }
+
+  .article-content :global(.bar-row.selected > span),
+  .article-content :global(.bar-row.selected strong) {
+    color: var(--text-primary);
+  }
+
+  .article-content :global(.chart-note) {
+    margin: 14px 0 0;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
+  .article-content :global(.mini-card-grid) {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 14px;
+    margin: 18px 0 34px;
+  }
+
+  .article-content :global(.mini-card) {
+    border: 1px solid var(--release-card-border);
+    border-radius: 8px;
+    background:
+      linear-gradient(180deg, var(--release-card-highlight), transparent 76%),
+      var(--release-card-bg);
+    padding: 16px;
+    box-shadow: inset 0 1px 0 var(--surface-inset-highlight);
+  }
+
+  .article-content :global(.mini-card span) {
+    display: block;
+    color: var(--text-muted);
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .article-content :global(.mini-card strong) {
+    display: block;
+    margin-top: 8px;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: clamp(1.55rem, 3vw, 2.1rem);
+    line-height: 1;
+  }
+
+  .article-content :global(.mini-card p) {
+    margin: 8px 0 0;
+    color: var(--text-secondary);
+    font-size: 0.94rem;
+    line-height: 1.45;
+  }
+
+  .article-content :global(.mini-card .muted-note),
+  .article-content :global(.timeline-list .muted-note) {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+  }
+
+  .article-content :global(.timeline-list) {
+    display: grid;
+    gap: 12px;
+    margin: 30px 0 40px;
+  }
+
+  .article-content :global(.timeline-list > div) {
+    position: relative;
+    border: 1px solid var(--release-card-border);
+    border-radius: 8px;
+    background:
+      linear-gradient(180deg, var(--release-card-highlight), transparent 76%),
+      var(--release-card-bg);
+    padding: 16px 18px 16px 46px;
+    box-shadow: inset 0 1px 0 var(--surface-inset-highlight);
+  }
+
+  .article-content :global(.timeline-list > div::before) {
+    content: '';
+    position: absolute;
+    left: 18px;
+    top: 22px;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: var(--release-data-ink);
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--release-data-ink) 14%, transparent);
+  }
+
+  .article-content :global(.timeline-list span) {
+    display: block;
+    color: var(--release-data-ink);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
+  .article-content :global(.timeline-list strong) {
+    display: block;
+    margin-top: 3px;
+  }
+
+  .article-content :global(.timeline-list p) {
+    margin: 4px 0 0;
   }
 
   .article-content :global(hr) {
@@ -677,6 +964,21 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
 
     .side-card {
       display: none;
+    }
+
+    .article-content :global(.metric-grid),
+    .article-content :global(.chart-grid),
+    .article-content :global(.mini-card-grid) {
+      grid-template-columns: 1fr;
+    }
+
+    .article-content :global(.bar-row) {
+      grid-template-columns: 1fr;
+      gap: 7px;
+    }
+
+    .article-content :global(.bar-row strong) {
+      text-align: left;
     }
 
     .article h1 {


### PR DESCRIPTION
## Summary
- add a founder/engineering blog post about OpenClaw performance, package size, dependency ownership, shrinkwrap, and supply-chain risk work
- add release-sweep cards/charts with shipped 5.27 endpoints and next-release notes where relevant
- tune blog article card styling for consistent dark/light contrast and chart readability

## Verification
- bun run build
- git diff --check
