### PR TITLE
fix(security): add Content-Security-Policy and hardening headers

### DIFF
--- a/tests/static-assets.test.ts
+++ b/tests/static-assets.test.ts
@@ -15,6 +15,10 @@ function readText(relativePath: string): string {
   return readFileSync(repoPath(relativePath), 'utf8');
 }
 
+function readJson(relativePath: string): unknown {
+  return JSON.parse(readText(relativePath));
+}
+
 function readBytes(relativePath: string): Buffer {
   return readFileSync(repoPath(relativePath));
 }
@@ -64,5 +68,36 @@ describe('static public assets', () => {
     expect(homepage).toContain("{ name: 'Twitter', icon: siIcon(siX)");
     expect(homepage).toContain("{ name: 'Browser', icon: siIcon(siGooglechrome)");
     expect(homepage).toContain("{ name: 'Gmail', icon: siIcon(siGmail)");
+  });
+
+  test('keeps Vercel security headers aligned with static site resource origins', () => {
+    const config = readJson('vercel.json') as {
+      headers?: Array<{
+        source?: string;
+        headers?: Array<{ key?: string; value?: string }>;
+      }>;
+    };
+    const globalHeaders = config.headers?.find((entry) => entry.source === '/(.*)')?.headers ?? [];
+    const headerMap = new Map(globalHeaders.map((header) => [header.key, header.value]));
+    const csp = headerMap.get('Content-Security-Policy') ?? '';
+
+    expect(headerMap.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(headerMap.get('X-Frame-Options')).toBe('DENY');
+    expect(headerMap.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(headerMap.get('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=()');
+
+    for (const requiredDirective of [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
+      "style-src 'self' 'unsafe-inline' https://api.fontshare.com",
+      "font-src 'self' https://cdn.fontshare.com",
+      "img-src 'self' data: https://ui-avatars.com https://pbs.twimg.com",
+      "connect-src 'self' https://vitals.vercel-analytics.com",
+      "frame-ancestors 'none'",
+      "form-action 'self' https://buttondown.com",
+      "base-uri 'self'",
+    ]) {
+      expect(csp).toContain(requiredDirective);
+    }
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,31 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com; font-src 'self' https://cdn.fontshare.com; img-src 'self' data: https://ui-avatars.com https://pbs.twimg.com; connect-src 'self' https://vitals.vercel-analytics.com; frame-ancestors 'none'; form-action 'self' https://buttondown.com; base-uri 'self'"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ],
   "routes": [
     {
       "src": "^/publications/?$",


### PR DESCRIPTION
## Problem

The site serves pages without any security response headers. Browsers
apply default-permissive policies for script loading, framing, MIME
sniffing, and referrer leakage. This leaves users exposed to
clickjacking, MIME-confusion attacks, and unrestricted resource
injection if any XSS vector is found.

## Fix

Add five security headers to `vercel.json`, applied to every route:

| Header | Value |
|--------|-------|
| **Content-Security-Policy** | Per-directive allowlist (see below) |
| **X-Content-Type-Options** | `nosniff` |
| **X-Frame-Options** | `DENY` |
| **Referrer-Policy** | `strict-origin-when-cross-origin` |
| **Permissions-Policy** | `camera=(), microphone=(), geolocation=()` |

**CSP directive breakdown**

Every external domain was identified by auditing all source files:

| Directive | Allowed origins | Reason |
|-----------|----------------|--------|
| `default-src` | `'self'` | Baseline restriction |
| `script-src` | `'self' 'unsafe-inline' https://va.vercel-scripts.com` | Astro `is:inline` theme toggle + Vercel Analytics |
| `style-src` | `'self' 'unsafe-inline' https://api.fontshare.com` | Astro inline styles + Fontshare CSS |
| `font-src` | `'self' https://cdn.fontshare.com` | Fontshare font files |
| `img-src` | `'self' data: https://ui-avatars.com https://pbs.twimg.com` | Local assets + avatar fallback + showcase/shoutout images |
| `connect-src` | `'self' https://vitals.vercel-analytics.com` | Analytics beacon |
| `frame-ancestors` | `'none'` | Prevent framing |
| `form-action` | `'self' https://buttondown.com` | Newsletter subscription form |
| `base-uri` | `'self'` | Prevent base-tag injection |

**Why `'unsafe-inline'` for scripts**

Astro's `<script is:inline>` directive (used for the theme toggle in
`Layout.astro`) emits literal inline `<script>` tags in the HTML
output. Nonce-based CSP requires runtime header injection, which is not
supported in Vercel's static build pipeline. Hash-based CSP would
require recomputing hashes on every content change. `'unsafe-inline'`
is the practical choice for this architecture.

## Real behavior proof

- **Behavior addressed:** The site served no Content-Security-Policy, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, or Permissions-Policy headers. Browsers applied default-permissive policies, leaving users exposed to clickjacking, MIME-confusion, and unrestricted resource injection.
- **Real environment tested:** macOS 15.5, Node v22.19, openclaw.ai repo at `fix/security-headers` branch, rebased onto upstream/main.
- **Exact steps or command run after this patch:**

  Step 1. Built the site from the patched branch, rebased onto latest upstream/main:

  ```console
  $ cd ~/openclaw.ai && npm install && npx astro build
  17 page(s) built in 1.46s
  ```

  Step 2. Created a Vercel-equivalent local server that reads `vercel.json` headers and applies them to every response (same behavior as Vercel's edge):

  ```console
  $ node vercel-sim.mjs ./dist
  Vercel-sim serving on http://localhost:4324
  ```

  Step 3. Curled multiple pages to verify all 5 security headers are delivered in the HTTP response.

  Step 4. Verified every external domain in the CSP appears in the source code.

- **Evidence after fix:** curl output from the Vercel-equivalent local server showing all 5 security headers delivered in the HTTP response:

  Home page response headers:

  ```console
  $ curl -sI http://localhost:4324/
  HTTP/1.1 200 OK
  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com; font-src 'self' https://cdn.fontshare.com; img-src 'self' data: https://ui-avatars.com https://pbs.twimg.com; connect-src 'self' https://vitals.vercel-analytics.com; frame-ancestors 'none'; form-action 'self' https://buttondown.com; base-uri 'self'
  X-Content-Type-Options: nosniff
  X-Frame-Options: DENY
  Referrer-Policy: strict-origin-when-cross-origin
  Permissions-Policy: camera=(), microphone=(), geolocation=()
  ```

  Showcase page (59 `pbs.twimg.com` images, allowed by `img-src`):

  ```console
  $ curl -sI http://localhost:4324/showcase/
  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com; font-src 'self' https://cdn.fontshare.com; img-src 'self' data: https://ui-avatars.com https://pbs.twimg.com; connect-src 'self' https://vitals.vercel-analytics.com; frame-ancestors 'none'; form-action 'self' https://buttondown.com; base-uri 'self'
  X-Content-Type-Options: nosniff
  X-Frame-Options: DENY
  Referrer-Policy: strict-origin-when-cross-origin
  Permissions-Policy: camera=(), microphone=(), geolocation=()
  ```

  Shoutouts page (community avatar images):

  ```console
  $ curl -sI http://localhost:4324/shoutouts/
  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com; font-src 'self' https://cdn.fontshare.com; img-src 'self' data: https://ui-avatars.com https://pbs.twimg.com; connect-src 'self' https://vitals.vercel-analytics.com; frame-ancestors 'none'; form-action 'self' https://buttondown.com; base-uri 'self'
  X-Content-Type-Options: nosniff
  X-Frame-Options: DENY
  Referrer-Policy: strict-origin-when-cross-origin
  Permissions-Policy: camera=(), microphone=(), geolocation=()
  ```

  External domain source verification (every CSP-allowed domain traced to source):

  ```console
  $ grep -c "pbs.twimg.com" src/data/showcase.json src/data/testimonials-extra.json
  src/data/showcase.json:56
  src/data/testimonials-extra.json:3

  $ grep -n "api.fontshare.com" src/layouts/Layout.astro
  46:    <link rel="preconnect" href="https://api.fontshare.com">
  48:    <link href="https://api.fontshare.com/v2/css?..." rel="stylesheet">

  $ grep -n "cdn.fontshare.com" src/layouts/Layout.astro
  47:    <link rel="preconnect" href="https://cdn.fontshare.com" crossorigin>

  $ grep -n "ui-avatars.com" src/lib/avatars.ts
  29:  return `https://ui-avatars.com/api/?${params}`;

  $ grep -n "buttondown" src/pages/index.astro
  760:  <form ... action="https://buttondown.com/api/emails/embed-subscribe/steipete" ...>
  ```

- **Observed result after fix:** All 5 security headers are delivered in the HTTP response on every page tested (home, showcase, shoutouts). The CSP string contains 9 well-formed directives. All 7 external domains (`va.vercel-scripts.com`, `api.fontshare.com`, `cdn.fontshare.com`, `ui-avatars.com`, `pbs.twimg.com`, `vitals.vercel-analytics.com`, `buttondown.com`) are verified present in the source code or `@vercel/analytics` package and allowed by the CSP. The 59 `pbs.twimg.com` URLs across `/showcase` and `/shoutouts` pages will load correctly under this CSP. `frame-ancestors: 'none'` blocks clickjacking. `base-uri: 'self'` prevents base-tag injection.
- **What was not tested:** Live Vercel production deployment. Fork PRs cannot trigger Vercel preview deploys. Header delivery was verified via a Vercel-equivalent local server that reads `vercel.json` and applies the headers to every HTTP response, matching Vercel's static header injection behavior.
