### PR TITLE
fix(blog): render social links as icons

### DIFF
--- a/src/components/SiteTopbar.astro
+++ b/src/components/SiteTopbar.astro
@@ -13,8 +13,8 @@ const { active = 'home' } = Astro.props;
 const items: NavItem[] = [
   { href: '/', label: 'Product' },
   { href: '/ecosystem', label: 'Ecosystem' },
-  { href: 'https://docs.openclaw.ai/', label: 'Docs', external: true },
   { href: '/blog', label: 'Blog' },
+  { href: 'https://docs.openclaw.ai/', label: 'Docs', external: true },
   { href: 'https://github.com/openclaw/openclaw', label: 'GitHub', external: true },
 ];
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,6 +3,8 @@ import { glob } from 'astro/loaders';
 
 const authorSchema = z.object({
   name: z.string(),
+  title: z.string().optional(),
+  org: z.string().optional(),
   handle: z.string().optional(),
   url: z.string().optional(),
   links: z.array(z.object({

--- a/src/content/blog/safer-than-yolo-auto-mode-for-exec-approvals.md
+++ b/src/content/blog/safer-than-yolo-auto-mode-for-exec-approvals.md
@@ -1,50 +1,63 @@
 ---
-title: "Auto Mode Is the Safer Way to Let Agents Run Commands"
-description: "OpenClaw is moving host exec from YOLO to auto: deterministic commands run, risky misses get reviewed, and humans stay in the approval loop."
+title: "Safer Than YOLO: Auto Mode for Exec Approvals"
+description: "OpenClaw is adding opt-in auto mode for Enterprise-ready host exec guardrails: policy runs first, low-risk misses get reviewed, and humans stay in the loop."
 date: 2026-05-31
 authors:
-  - name: "Vince Koc"
+  - name: "Vincent Koc"
+    title: "Chief Architect"
+    org: "OpenClaw Foundation"
     handle: "vincent_koc"
+    links:
+      - label: "LinkedIn"
+        url: "https://www.linkedin.com/in/koconder/"
+      - label: "@vincent_koc"
+        url: "https://x.com/vincent_koc"
     avatar: "/blog/authors/vince-koc.jpg"
   - name: "Jesse Merhi"
+    title: "Core Maintainer"
+    org: "OpenClaw / Atlassian"
     links:
       - label: "LinkedIn"
         url: "https://www.linkedin.com/in/jesse-merhi/"
       - label: "@jesse_merhi"
         url: "https://x.com/jesse_merhi"
     avatar: "/blog/authors/jesse-merhi.jpg"
-draft: true
+draft: false
 tags: ["security", "codex", "approvals", "channels"]
 ---
 
-YOLO mode made host commands fast by skipping approval prompts. That was useful for trusted local automation, but too blunt for everyday use.
+YOLO mode made host commands fast by skipping approval prompts. That is useful for trusted local automation and externally sandboxed runs, but it is too blunt as the only good answer for everyday use.
 
-`auto` is the safer default.
+We are not changing the default today.
+
+`auto` is an opt-in path we are testing in public. If it proves useful, we will consider making it the safer default for more users, but the principle stays the same: OpenClaw should protect people without taking away operator choice.
+
+Auto is the mode that fits Enterprise environments best: policy runs first, low-risk misses can be reviewed by a model, and anything uncertain still routes to a human.
 
 Safe, repeatable commands can run without nagging you. Commands that miss policy go to a reviewer first. If the reviewer is not confident, OpenClaw asks you.
 
-We shipped this first through the [Codex harness](https://docs.openclaw.ai/plugins/codex-harness), so OpenAI-backed OpenClaw sessions could already use Codex-style auto approvals. Now we are bringing the same safer default to host exec for everyone.
+OpenAI already ships this pattern as Guardian inside Codex. Through the [Codex harness](https://docs.openclaw.ai/plugins/codex-harness), OpenAI-backed OpenClaw sessions can use Codex-native reviewed approvals. Now we are bringing the same shape to OpenClaw host exec as an opt-in mode for everyone.
 
 ## Why This Exists
 
-Codex already made this shift in its own permission presets. Its `auto` preset is the default: workspace files are writable, normal commands can run, and approvals are still required for escapes such as network access or writes outside the workspace.
+Codex already made this shift in its own permission presets. Its Guardian-reviewed flow lets common workspace work proceed while still requiring review for escapes such as network access or writes outside the workspace.
 
 OpenClaw is bringing the same shape to [host exec](https://docs.openclaw.ai/tools/exec-approvals). `tools.exec.mode: "auto"` keeps the agent moving without turning every command into a permanent yes.
 
 <section class="mini-card-grid" aria-label="Exec mode comparison">
   <div class="mini-card">
     <span>Ask</span>
-    <strong>Human first</strong>
+    <strong><span>Human</span><span>first</span></strong>
     <p>Allowlist misses stop and wait for an operator. Good for strict setups, noisy for busy agents.</p>
   </div>
   <div class="mini-card">
     <span>Auto</span>
-    <strong>Reviewer first</strong>
+    <strong><span>Reviewer</span><span>first</span></strong>
     <p>Deterministic matches run. Misses go through OpenClaw's native auto reviewer before a human fallback.</p>
   </div>
   <div class="mini-card">
     <span>YOLO</span>
-    <strong>No prompts</strong>
+    <strong><span>No</span><span>prompts</span></strong>
     <p>Host exec runs without approval prompts. Useful only when the surrounding environment is already trusted.</p>
   </div>
 </section>
@@ -52,6 +65,8 @@ OpenClaw is bringing the same shape to [host exec](https://docs.openclaw.ai/tool
 ## What Auto Does
 
 Host exec starts with OpenClaw config: what the agent is allowed to ask for. Most users only need that setting. Hosts can still apply stricter local policy.
+
+The reviewer model is separate from the main agent model. You can keep the agent on local models for normal work and point exec review at a frontier model such as `openai/gpt-5.5` when you want stronger judgment on approval misses. That gives you the best of both worlds: local-first execution for ordinary turns, higher-confidence review only when host access needs a decision.
 
 In `auto` mode, OpenClaw handles a host command like this:
 
@@ -72,9 +87,17 @@ openclaw config set tools.exec.host gateway
 openclaw config set tools.exec.mode auto
 ```
 
-Auto is now active for host exec.
+That host has now opted into auto for host exec.
 
-If you use the [Codex harness](https://docs.openclaw.ai/plugins/codex-harness), this is the path OpenAI-backed sessions already use: `tools.exec.mode: "auto"` maps Codex app-server sessions to reviewed approvals with workspace-write sandboxing when available.
+If you want review to use a stronger model than the main agent, set the reviewer model separately:
+
+```bash
+openclaw config set tools.exec.reviewer.model openai/gpt-5.5
+```
+
+Leave it unset to reuse the current agent model.
+
+If you use the [Codex harness](https://docs.openclaw.ai/plugins/codex-harness), this maps OpenAI-backed sessions onto Codex Guardian-reviewed approvals with workspace-write sandboxing when available.
 
 ## What Gets Asked
 
@@ -100,4 +123,4 @@ The detailed setup lives in [Exec approvals - advanced](https://docs.openclaw.ai
 
 The reviewer may only allow one low-risk execution. It is prompted to treat the command text, argv, cwd, env keys, heredocs, strings, filenames, and metadata as untrusted data. If that untrusted data tries to instruct the reviewer or request a decision, OpenClaw defers to a human.
 
-YOLO remains available for environments that are already externally sandboxed or deliberately trusted. For most users, `auto` is the better default: fewer prompts than strict ask mode, less risk than full host access.
+YOLO remains available for environments that are already externally sandboxed or deliberately trusted. For Enterprise environments, `auto` is the better fit: fewer prompts than strict ask mode, more review than full host access, and a human fallback when the reviewer cannot safely say yes. We are not forcing that switch yet.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,13 +5,19 @@ interface Props {
   title: string;
   description?: string;
   canonicalUrl?: string;
+  ogType?: string;
+  structuredData?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const {
   title,
   description = "OpenClaw — The AI that actually does things. Your personal assistant on any platform.",
   canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? "https://openclaw.ai").href,
+  ogType = "website",
+  structuredData,
 } = Astro.props;
+
+const structuredDataItems = structuredData ? Array.isArray(structuredData) ? structuredData : [structuredData] : [];
 ---
 
 <!doctype html>
@@ -30,7 +36,7 @@ const {
     <!-- Open Graph -->
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:image" content="https://openclaw.ai/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -48,6 +54,10 @@ const {
     <link href="https://api.fontshare.com/v2/css?f[]=clash-display@700,600,500&f[]=satoshi@400,500,700&display=swap" rel="stylesheet">
 
     <title>{title}</title>
+
+    {structuredDataItems.map((item) => (
+      <script type="application/ld+json" set:html={JSON.stringify(item)} />
+    ))}
 
     <script is:inline>
       (() => {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -3,6 +3,7 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 export type BlogPost = CollectionEntry<'blog'>;
 
 export async function getPublishedBlogPosts(): Promise<BlogPost[]> {
-  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  const includeDrafts = import.meta.env.OPENCLAW_BLOG_PREVIEW_DRAFTS === '1';
+  const posts = await getCollection('blog', ({ data }) => includeDrafts || !data.draft);
   return posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,33 @@
+import type { CollectionEntry } from 'astro:content';
+
+export const SITE_URL = 'https://openclaw.ai';
+export const PUBLICATION_NAME = 'OpenClaw Blog';
+export const PUBLICATION_LANGUAGE = 'en';
+
+export type BlogPost = CollectionEntry<'blog'>;
+
+export function absoluteUrl(pathname: string): string {
+  return new URL(pathname, SITE_URL).href;
+}
+
+export function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export function sitemapUrl(pathname: string, lastmod?: Date): string {
+  return [
+    '  <url>',
+    `    <loc>${xmlEscape(absoluteUrl(pathname))}</loc>`,
+    lastmod ? `    <lastmod>${lastmod.toISOString()}</lastmod>` : null,
+    '  </url>',
+  ].filter(Boolean).join('\n');
+}
+
+export function blogPostPath(post: BlogPost): string {
+  return `/blog/${post.id}`;
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,10 +1,13 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import Icon from '../../components/Icon.astro';
 import SiteTopbar from '../../components/SiteTopbar.astro';
 import { render } from 'astro:content';
 import { getPublishedBlogPosts } from '../../lib/blog';
 import { getCachedXAvatarSrc, getInitialsAvatarSrc } from '../../lib/avatars';
 import { sanitizeUrl } from '../../lib/sanitize-url';
+import { SITE_URL, absoluteUrl, blogPostPath } from '../../lib/seo';
+import { siGithub, siX } from 'simple-icons';
 
 export async function getStaticPaths() {
   const posts = await getPublishedBlogPosts();
@@ -19,7 +22,8 @@ const allPosts = await getPublishedBlogPosts();
 const { Content, headings } = await render(post);
 
 type AuthorLink = { label: string; url: string };
-type Author = { name: string; handle?: string; url?: string; links?: AuthorLink[]; avatar?: string };
+type Author = { name: string; title?: string; org?: string; handle?: string; url?: string; links?: AuthorLink[]; avatar?: string };
+type AuthorLinkMeta = AuthorLink & { displayLabel: string; icon?: string; ariaLabel: string; order: number };
 const authors: Author[] = post.data.authors
   ? post.data.authors
   : post.data.author
@@ -43,6 +47,41 @@ function getAuthorLinks(author: Author): AuthorLink[] {
     label: author.handle ? `@${author.handle}` : new URL(url).hostname.replace(/^www\./, ''),
     url,
   }];
+}
+
+const siIcon = (icon: { path: string }) => icon.path;
+const linkedinIcon = 'M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.46v6.28zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.23 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.73C24 .77 23.2 0 22.23 0z';
+
+function getAuthorLinkMeta(author: Author, link: AuthorLink): AuthorLinkMeta {
+  const label = link.label.trim();
+  const normalizedLabel = label.toLowerCase();
+  let hostname = '';
+
+  try {
+    hostname = new URL(link.url).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    hostname = '';
+  }
+
+  if (hostname === 'x.com' || hostname === 'twitter.com' || normalizedLabel === 'x' || normalizedLabel.startsWith('@')) {
+    return { ...link, displayLabel: 'X', icon: siIcon(siX), ariaLabel: `${author.name} on X`, order: 0 };
+  }
+
+  if (hostname.endsWith('linkedin.com') || normalizedLabel.includes('linkedin')) {
+    return { ...link, displayLabel: 'LinkedIn', icon: linkedinIcon, ariaLabel: `${author.name} on LinkedIn`, order: 1 };
+  }
+
+  if (hostname === 'github.com' || normalizedLabel.includes('github')) {
+    return { ...link, displayLabel: 'GitHub', icon: siIcon(siGithub), ariaLabel: `${author.name} on GitHub`, order: 2 };
+  }
+
+  return { ...link, displayLabel: label, ariaLabel: `${author.name}: ${label}`, order: 3 };
+}
+
+function getSortedAuthorLinkMeta(author: Author): AuthorLinkMeta[] {
+  return getAuthorLinks(author)
+    .map((link, index) => ({ ...getAuthorLinkMeta(author, link), index }))
+    .sort((a, b) => a.order - b.order || a.index - b.index);
 }
 
 function formatDate(date: Date): string {
@@ -77,10 +116,45 @@ const relatedPosts = allPosts
   .slice(0, 3)
   .map((item) => item.post);
 
-const postUrl = `https://openclaw.ai/blog/${post.id}`;
+const canonicalPostUrl = absoluteUrl(blogPostPath(post));
+const articleImageUrl = post.data.image ? new URL(post.data.image, SITE_URL).href : absoluteUrl('/og-image.png');
+const structuredAuthors = authors.map((author) => {
+  const profileUrl = getSortedAuthorLinkMeta(author).find((link) => sanitizeUrl(link.url) !== '#')?.url;
+  return {
+    '@type': 'Person',
+    name: author.name,
+    ...(profileUrl ? { url: profileUrl } : {}),
+  };
+});
+const articleStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  headline: post.data.title,
+  description: post.data.description,
+  url: canonicalPostUrl,
+  mainEntityOfPage: canonicalPostUrl,
+  datePublished: post.data.date.toISOString(),
+  dateModified: post.data.date.toISOString(),
+  image: [articleImageUrl],
+  author: structuredAuthors.length > 0 ? structuredAuthors : [{ '@type': 'Organization', name: 'OpenClaw' }],
+  publisher: {
+    '@type': 'Organization',
+    name: 'OpenClaw',
+    logo: {
+      '@type': 'ImageObject',
+      url: absoluteUrl('/logo.png'),
+    },
+  },
+};
 ---
 
-<Layout title={`${post.data.title} - OpenClaw Blog`} description={post.data.description}>
+<Layout
+  title={`${post.data.title} - OpenClaw Blog`}
+  description={post.data.description}
+  canonicalUrl={canonicalPostUrl}
+  ogType="article"
+  structuredData={articleStructuredData}
+>
   <SiteTopbar active="blog" />
   <div class="stars"></div>
   <div class="nebula"></div>
@@ -115,7 +189,7 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
         <div class="article-meta">
           <div class="authors-container">
             {authors.map((author) => (
-              <div class="author-info">
+              <div class:list={['author-info', !(author.title || author.org) && 'author-info-compact']}>
                 <img
                   src={getAuthorAvatar(author)}
                   alt={author.name}
@@ -123,12 +197,27 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
                   loading="lazy"
                   onerror={`this.src='${getInitialsAvatarSrc(author.name, 88)}'`}
                 />
-                <div class="author-details">
+                <div class:list={['author-details', !(author.title || author.org) && 'author-details-compact']}>
                   <span class="author-name">{author.name}</span>
+                  {(author.title || author.org) && (
+                    <span class="author-title">
+                      {author.title && <span class="author-role">{author.title}</span>}
+                      {author.org && <span class="author-org">{author.org}</span>}
+                    </span>
+                  )}
                   {getAuthorLinks(author).length > 0 && (
                     <div class="author-links">
-                      {getAuthorLinks(author).map((link) => (
-                        <a href={sanitizeUrl(link.url)} class="author-handle" target="_blank" rel="noopener">{link.label}</a>
+                      {getSortedAuthorLinkMeta(author).map((linkMeta) => (
+                          <a
+                            href={sanitizeUrl(linkMeta.url)}
+                            class:list={['author-link', linkMeta.icon && 'author-link-icon']}
+                            target="_blank"
+                            rel="noopener"
+                            aria-label={linkMeta.ariaLabel}
+                            title={linkMeta.displayLabel}
+                          >
+                            {linkMeta.icon ? <Icon icon={linkMeta.icon} size={13} /> : linkMeta.displayLabel}
+                          </a>
                       ))}
                     </div>
                   )}
@@ -150,10 +239,17 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
       <footer class="article-footer">
         <section class="share-section">
           <span>Share this post</span>
-          <a href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.data.title)}&url=${encodeURIComponent(postUrl)}&via=openclaw`} target="_blank" rel="noopener">
-            X
+          <a
+            href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.data.title)}&url=${encodeURIComponent(canonicalPostUrl)}&via=openclaw`}
+            class="share-link share-link-icon"
+            target="_blank"
+            rel="noopener"
+            aria-label="Share on X"
+            title="Share on X"
+          >
+            <Icon icon={siIcon(siX)} size={14} />
           </a>
-          <a href={`https://news.ycombinator.com/submitlink?u=${encodeURIComponent(postUrl)}&t=${encodeURIComponent(post.data.title)}`} target="_blank" rel="noopener">
+          <a class="share-link" href={`https://news.ycombinator.com/submitlink?u=${encodeURIComponent(canonicalPostUrl)}&t=${encodeURIComponent(post.data.title)}`} target="_blank" rel="noopener">
             Hacker News
           </a>
         </section>
@@ -343,18 +439,23 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
   .authors-container {
     display: flex;
     flex-wrap: wrap;
-    gap: 16px;
+    gap: 18px 24px;
   }
 
   .author-info {
     display: flex;
+    align-items: flex-start;
+    gap: 11px;
+  }
+
+  .author-info-compact {
     align-items: center;
-    gap: 12px;
   }
 
   .author-avatar {
     width: 44px;
     height: 44px;
+    margin-top: 1px;
     border-radius: 50%;
     border: 1px solid var(--border-subtle);
     background: var(--bg-elevated);
@@ -363,6 +464,11 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
   .author-details {
     display: flex;
     flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .author-details-compact {
     gap: 2px;
   }
 
@@ -371,16 +477,63 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
     font-weight: 750;
   }
 
+  .author-title {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    max-width: 260px;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    line-height: 1.22;
+  }
+
+  .author-role {
+    font-weight: 700;
+  }
+
+  .author-org {
+    font-weight: 560;
+    color: color-mix(in srgb, var(--text-muted) 82%, var(--text-primary));
+  }
+
   .author-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px 10px;
+    gap: 5px;
+    margin-top: 3px;
   }
 
-  .author-handle {
+  .author-details-compact .author-links {
+    margin-top: 1px;
+  }
+
+  .author-link {
     color: var(--coral-bright);
     font-size: 0.85rem;
     text-decoration: none;
+  }
+
+  .author-link-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--border-subtle);
+    border-radius: 7px;
+    background: var(--surface-card);
+    color: var(--text-primary);
+    transition: border-color 140ms ease, color 140ms ease, transform 140ms ease;
+  }
+
+  .author-link-icon:hover {
+    border-color: var(--coral-bright);
+    color: var(--coral-bright);
+    transform: translateY(-1px);
+  }
+
+  .author-link-icon :global(svg) {
+    display: block;
   }
 
   .meta-right {
@@ -752,6 +905,14 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
     line-height: 1;
   }
 
+  .article-content :global(.mini-card strong span) {
+    display: block;
+    color: inherit;
+    font: inherit;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
   .article-content :global(.mini-card p) {
     margin: 8px 0 0;
     color: var(--text-secondary);
@@ -863,7 +1024,7 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
     font-size: 0.9rem;
   }
 
-  .share-section a,
+  .share-link,
   .cta-box a {
     display: inline-flex;
     align-items: center;
@@ -877,7 +1038,17 @@ const postUrl = `https://openclaw.ai/blog/${post.id}`;
     text-decoration: none;
   }
 
-  .share-section a:hover,
+  .share-link-icon {
+    justify-content: center;
+    width: 32px;
+    padding: 0;
+  }
+
+  .share-link-icon :global(svg) {
+    display: block;
+  }
+
+  .share-link:hover,
   .cta-box a:hover {
     border-color: var(--coral-bright);
     color: var(--coral-bright);

--- a/src/pages/news-sitemap.xml.ts
+++ b/src/pages/news-sitemap.xml.ts
@@ -1,0 +1,46 @@
+import { getPublishedBlogPosts } from '../lib/blog';
+import {
+  PUBLICATION_LANGUAGE,
+  PUBLICATION_NAME,
+  absoluteUrl,
+  blogPostPath,
+  xmlEscape,
+} from '../lib/seo';
+
+const TWO_DAYS_MS = 2 * 24 * 60 * 60 * 1000;
+
+function newsUrl(post: Awaited<ReturnType<typeof getPublishedBlogPosts>>[number]): string {
+  return [
+    '  <url>',
+    `    <loc>${xmlEscape(absoluteUrl(blogPostPath(post)))}</loc>`,
+    '    <news:news>',
+    '      <news:publication>',
+    `        <news:name>${xmlEscape(PUBLICATION_NAME)}</news:name>`,
+    `        <news:language>${PUBLICATION_LANGUAGE}</news:language>`,
+    '      </news:publication>',
+    `      <news:publication_date>${post.data.date.toISOString()}</news:publication_date>`,
+    `      <news:title>${xmlEscape(post.data.title)}</news:title>`,
+    '    </news:news>',
+    '  </url>',
+  ].join('\n');
+}
+
+export async function GET() {
+  const now = Date.now();
+  const posts = await getPublishedBlogPosts();
+  const recentPosts = posts.filter((post) => {
+    const publishedAt = post.data.date.valueOf();
+    return publishedAt <= now && now - publishedAt <= TWO_DAYS_MS;
+  });
+
+  return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+${recentPosts.map(newsUrl).join('\n')}
+</urlset>
+`, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,15 @@
+import { absoluteUrl } from '../lib/seo';
+
+export function GET() {
+  return new Response([
+    'User-agent: *',
+    'Allow: /',
+    `Sitemap: ${absoluteUrl('/sitemap.xml')}`,
+    `Sitemap: ${absoluteUrl('/news-sitemap.xml')}`,
+    '',
+  ].join('\n'), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+}

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,32 @@
+import { getPublishedBlogPosts } from '../lib/blog';
+import { blogPostPath, sitemapUrl } from '../lib/seo';
+
+const staticPaths = [
+  '/',
+  '/blog',
+  '/ecosystem',
+  '/integrations',
+  '/press',
+  '/privacy',
+  '/showcase',
+  '/shoutouts',
+  '/cat',
+];
+
+export async function GET() {
+  const posts = await getPublishedBlogPosts();
+  const urls = [
+    ...staticPaths.map((pathname) => sitemapUrl(pathname)),
+    ...posts.map((post) => sitemapUrl(blogPostPath(post), post.data.date)),
+  ];
+
+  return new Response(`<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- render blog author/share social links as icons with stable ordering
- publish the YOLO auto-mode post at the title-matched slug
- add sitemap, Google News sitemap, robots, and article structured data support
- move Blog before Docs in the top navigation

## Validation
- bun run build
- xmllint --noout dist/sitemap.xml dist/news-sitemap.xml dist/rss.xml
- verified /blog/safer-than-yolo-auto-mode-for-exec-approvals renders locally
