### PR TITLE
fix(blog): centralize author profiles

### DIFF
--- a/src/content/blog/introducing-openclaw.md
+++ b/src/content/blog/introducing-openclaw.md
@@ -3,7 +3,6 @@ title: "Introducing OpenClaw"
 description: "The journey from Clawd to Moltbot to OpenClaw—and why this name is here to stay."
 date: 2026-01-29
 author: "Peter Steinberger"
-authorHandle: "steipete"
 tags: ["announcement", "roadmap"]
 image: "/blog/openclaw-logo-text.png"
 ---

--- a/src/content/blog/lighter-core-sharper-claws.md
+++ b/src/content/blog/lighter-core-sharper-claws.md
@@ -3,7 +3,6 @@ title: "OpenClaw Is Getting Faster, Smaller, and Easier to Trust"
 description: "A release sweep across February through May shows faster agent turns, fewer dependencies, and a cleaner package shape."
 date: 2026-05-28
 author: "Peter Steinberger"
-authorHandle: "steipete"
 draft: false
 tags: ["performance", "release", "security", "dependencies"]
 ---

--- a/src/content/blog/openai-models-in-openclaw-done-right.md
+++ b/src/content/blog/openai-models-in-openclaw-done-right.md
@@ -3,7 +3,6 @@ title: "OpenAI Models in OpenClaw, Done Right"
 description: "OpenClaw now runs OpenAI agent turns through the native Codex app-server harness by default, while bringing the lessons back to every model."
 date: 2026-05-14
 author: "Nik Pash"
-authorHandle: "pashmerepat"
 draft: false
 tags: ["models", "openai", "codex", "agents"]
 ---

--- a/src/content/blog/openclaw-rough-week.md
+++ b/src/content/blog/openclaw-rough-week.md
@@ -3,7 +3,6 @@ title: "OpenClaw Had a Rough Week"
 description: "What happened around the 2026.4.24 and 2026.4.29 releases, why the direction was right, and what we are changing now."
 date: 2026-05-05
 author: "Peter Steinberger"
-authorHandle: "steipete"
 draft: false
 tags: ["release", "stability", "security", "clawhub"]
 ---

--- a/src/content/blog/openclaw-security-in-public.md
+++ b/src/content/blog/openclaw-security-in-public.md
@@ -3,7 +3,6 @@ title: "How OpenClaw Got Safer in Public"
 description: "The work you do not see behind the world's most-watched open source personal AI agent."
 date: 2026-04-30
 author: "Peter Steinberger"
-authorHandle: "steipete"
 draft: false
 tags: ["security", "open-source", "nvidia", "clawhub"]
 ---

--- a/src/content/blog/safer-than-yolo-auto-mode-for-exec-approvals.md
+++ b/src/content/blog/safer-than-yolo-auto-mode-for-exec-approvals.md
@@ -4,24 +4,7 @@ description: "OpenClaw is adding opt-in auto mode for Enterprise-ready host exec
 date: 2026-05-31
 authors:
   - name: "Vincent Koc"
-    title: "Chief Architect"
-    org: "OpenClaw Foundation"
-    handle: "vincent_koc"
-    links:
-      - label: "LinkedIn"
-        url: "https://www.linkedin.com/in/koconder/"
-      - label: "@vincent_koc"
-        url: "https://x.com/vincent_koc"
-    avatar: "/blog/authors/vince-koc.jpg"
   - name: "Jesse Merhi"
-    title: "Core Maintainer"
-    org: "OpenClaw / Atlassian"
-    links:
-      - label: "LinkedIn"
-        url: "https://www.linkedin.com/in/jesse-merhi/"
-      - label: "@jesse_merhi"
-        url: "https://x.com/jesse_merhi"
-    avatar: "/blog/authors/jesse-merhi.jpg"
 draft: false
 tags: ["security", "codex", "approvals", "channels"]
 ---

--- a/src/content/blog/virustotal-partnership.md
+++ b/src/content/blog/virustotal-partnership.md
@@ -4,11 +4,8 @@ description: "ClawHub skills are now scanned by VirusTotal's threat intelligence
 date: 2026-02-07
 authors:
   - name: "Peter Steinberger"
-    handle: "steipete"
   - name: "Jamieson O'Reilly"
-    handle: "theonejvo"
   - name: "Bernardo Quintero"
-    handle: "bquintero"
 draft: false
 tags: ["security", "announcement", "clawhub"]
 image: "/blog/openclaw-virustotal.svg"

--- a/src/content/blog/where-openclaw-security-is-heading.md
+++ b/src/content/blog/where-openclaw-security-is-heading.md
@@ -4,12 +4,6 @@ description: "The security roadmap for making OpenClaw a powerful personal assis
 date: 2026-05-15
 authors:
   - name: "Jesse Merhi"
-    links:
-      - label: "LinkedIn"
-        url: "https://www.linkedin.com/in/jesse-merhi/"
-      - label: "@jesse_merhi"
-        url: "https://x.com/jesse_merhi"
-    avatar: "/blog/authors/jesse-merhi.jpg"
 draft: false
 tags: ["security", "open-source", "clawhub", "plugins"]
 ---

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -1,0 +1,92 @@
+export type AuthorLink = {
+  label: string;
+  url: string;
+};
+
+export type BlogAuthor = {
+  name: string;
+  title?: string;
+  org?: string;
+  handle?: string;
+  url?: string;
+  links?: AuthorLink[];
+  avatar?: string;
+};
+
+const authorProfiles: BlogAuthor[] = [
+  {
+    name: 'Vincent Koc',
+    title: 'Chief Architect',
+    org: 'OpenClaw Foundation',
+    handle: 'vincent_koc',
+    links: [
+      { label: '@vincent_koc', url: 'https://x.com/vincent_koc' },
+      { label: 'LinkedIn', url: 'https://www.linkedin.com/in/koconder/' },
+    ],
+    avatar: '/blog/authors/vince-koc.jpg',
+  },
+  {
+    name: 'Jesse Merhi',
+    title: 'Core Maintainer',
+    org: 'OpenClaw / Atlassian',
+    handle: 'jesse_merhi',
+    links: [
+      { label: '@jesse_merhi', url: 'https://x.com/jesse_merhi' },
+      { label: 'LinkedIn', url: 'https://www.linkedin.com/in/jesse-merhi/' },
+    ],
+    avatar: '/blog/authors/jesse-merhi.jpg',
+  },
+  {
+    name: 'Peter Steinberger',
+    title: 'Clawfather',
+    org: 'OpenClaw Foundation',
+    handle: 'steipete',
+  },
+  {
+    name: 'Nik Pash',
+    title: 'Core Maintainer',
+    org: 'OpenClaw / OpenAI',
+    handle: 'pashmerepat',
+  },
+  {
+    name: "Jamieson O'Reilly",
+    handle: 'theonejvo',
+  },
+  {
+    name: 'Bernardo Quintero',
+    handle: 'bquintero',
+  },
+];
+
+function authorKey(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+const profilesByName = new Map<string, BlogAuthor>();
+const profilesByHandle = new Map<string, BlogAuthor>();
+
+for (const profile of authorProfiles) {
+  const nameKey = authorKey(profile.name);
+  const handleKey = authorKey(profile.handle);
+  if (nameKey) profilesByName.set(nameKey, profile);
+  if (handleKey) profilesByHandle.set(handleKey, profile);
+}
+
+export function resolveAuthorProfile(author: BlogAuthor): BlogAuthor {
+  const profile =
+    profilesByName.get(authorKey(author.name) ?? '') ??
+    profilesByHandle.get(authorKey(author.handle) ?? '');
+
+  if (!profile) return author;
+
+  return {
+    name: author.name,
+    title: author.title ?? profile.title,
+    org: author.org ?? profile.org,
+    handle: author.handle ?? profile.handle,
+    url: author.url ?? profile.url,
+    links: author.links?.length ? author.links : profile.links,
+    avatar: author.avatar ?? profile.avatar,
+  };
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -4,6 +4,7 @@ import Icon from '../../components/Icon.astro';
 import SiteTopbar from '../../components/SiteTopbar.astro';
 import { render } from 'astro:content';
 import { getPublishedBlogPosts } from '../../lib/blog';
+import { resolveAuthorProfile, type AuthorLink, type BlogAuthor } from '../../lib/authors';
 import { getCachedXAvatarSrc, getInitialsAvatarSrc } from '../../lib/avatars';
 import { sanitizeUrl } from '../../lib/sanitize-url';
 import { SITE_URL, absoluteUrl, blogPostPath } from '../../lib/seo';
@@ -21,25 +22,23 @@ const { post } = Astro.props;
 const allPosts = await getPublishedBlogPosts();
 const { Content, headings } = await render(post);
 
-type AuthorLink = { label: string; url: string };
-type Author = { name: string; title?: string; org?: string; handle?: string; url?: string; links?: AuthorLink[]; avatar?: string };
 type AuthorLinkMeta = AuthorLink & { displayLabel: string; icon?: string; ariaLabel: string; order: number };
-const authors: Author[] = post.data.authors
-  ? post.data.authors
-  : post.data.author
+const rawAuthors: BlogAuthor[] = post.data.authors
+  ?? (post.data.author
     ? [{
-        name: post.data.author,
-        handle: post.data.authorHandle,
-        url: post.data.authorUrl,
-        avatar: post.data.authorAvatar,
-      }]
-    : [];
+      name: post.data.author,
+      handle: post.data.authorHandle,
+      url: post.data.authorUrl,
+      avatar: post.data.authorAvatar,
+    }]
+    : []);
+const authors = rawAuthors.map(resolveAuthorProfile);
 
-function getAuthorAvatar(author: Author): string {
+function getAuthorAvatar(author: BlogAuthor): string {
   return author.avatar ?? (author.handle ? getCachedXAvatarSrc(author.handle, author.name, 88) : '/openclaw-logo-text-dark.png');
 }
 
-function getAuthorLinks(author: Author): AuthorLink[] {
+function getAuthorLinks(author: BlogAuthor): AuthorLink[] {
   if (author.links?.length) return author.links;
   const url = author.url ?? (author.handle ? `https://x.com/${author.handle}` : null);
   if (!url) return [];
@@ -52,7 +51,7 @@ function getAuthorLinks(author: Author): AuthorLink[] {
 const siIcon = (icon: { path: string }) => icon.path;
 const linkedinIcon = 'M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.46v6.28zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.23 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.73C24 .77 23.2 0 22.23 0z';
 
-function getAuthorLinkMeta(author: Author, link: AuthorLink): AuthorLinkMeta {
+function getAuthorLinkMeta(author: BlogAuthor, link: AuthorLink): AuthorLinkMeta {
   const label = link.label.trim();
   const normalizedLabel = label.toLowerCase();
   let hostname = '';
@@ -78,7 +77,7 @@ function getAuthorLinkMeta(author: Author, link: AuthorLink): AuthorLinkMeta {
   return { ...link, displayLabel: label, ariaLabel: `${author.name}: ${label}`, order: 3 };
 }
 
-function getSortedAuthorLinkMeta(author: Author): AuthorLinkMeta[] {
+function getSortedAuthorLinkMeta(author: BlogAuthor): AuthorLinkMeta[] {
   return getAuthorLinks(author)
     .map((link, index) => ({ ...getAuthorLinkMeta(author, link), index }))
     .sort((a, b) => a.order - b.order || a.index - b.index);

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import SiteTopbar from '../../components/SiteTopbar.astro';
 import { getPublishedBlogPosts } from '../../lib/blog';
+import { resolveAuthorProfile, type BlogAuthor } from '../../lib/authors';
 import { getCachedXAvatarSrc, getInitialsAvatarSrc } from '../../lib/avatars';
 
 const posts = await getPublishedBlogPosts();
@@ -39,18 +40,16 @@ function estimateReadTime(content: string): string {
   return `${Math.max(1, Math.ceil(words / 220))} min read`;
 }
 
-type Author = { name: string; handle?: string; url?: string; avatar?: string };
-
-function firstAuthor(post: (typeof posts)[number]): Author {
-  return post.data.authors?.[0] ?? {
+function firstAuthor(post: (typeof posts)[number]): BlogAuthor {
+  return resolveAuthorProfile(post.data.authors?.[0] ?? {
     name: post.data.author ?? 'OpenClaw Team',
     handle: post.data.authorHandle,
     url: post.data.authorUrl,
     avatar: post.data.authorAvatar,
-  };
+  });
 }
 
-function getAuthorAvatar(author: Author): string {
+function getAuthorAvatar(author: BlogAuthor): string {
   return author.avatar ?? (author.handle ? getCachedXAvatarSrc(author.handle, author.name, 88) : '/openclaw-logo-text-dark.png');
 }
 ---


### PR DESCRIPTION
## Summary
- add shared blog author profiles for titles, orgs, handles, links, and avatars
- resolve profiles for article bylines and blog index author cards
- remove duplicated author profile fields from post frontmatter

## Validation
- bun run build
- checked generated bylines for Vincent, Jesse, Peter, and Nik
- checked local preview for Peter profile/link after dev restart
