### PR TITLE
fix(blog): order auto mode authors

### DIFF
--- a/src/content/blog/safer-than-yolo-auto-mode-for-exec-approvals.md
+++ b/src/content/blog/safer-than-yolo-auto-mode-for-exec-approvals.md
@@ -3,9 +3,9 @@ title: "Safer Than YOLO: Auto Mode for Exec Approvals"
 description: "OpenClaw is adding opt-in auto mode for Enterprise-ready host exec guardrails: policy runs first, low-risk misses get reviewed, and humans stay in the loop."
 date: 2026-05-31
 authors:
-  - name: "Josh Avant"
   - name: "Vincent Koc"
   - name: "Jesse Merhi"
+  - name: "Josh Avant"
 draft: false
 tags: ["security", "codex", "approvals", "channels"]
 ---

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -15,16 +15,6 @@ export type BlogAuthor = {
 
 const authorProfiles: BlogAuthor[] = [
   {
-    name: 'Josh Avant',
-    title: 'Core Maintainer',
-    org: 'OpenClaw Foundation',
-    handle: 'josh_avant',
-    links: [
-      { label: '@josh_avant', url: 'https://x.com/josh_avant' },
-    ],
-    avatar: '/avatars/x/josh_avant.jpg',
-  },
-  {
     name: 'Vincent Koc',
     title: 'Chief Architect',
     org: 'OpenClaw Foundation',
@@ -45,6 +35,16 @@ const authorProfiles: BlogAuthor[] = [
       { label: 'LinkedIn', url: 'https://www.linkedin.com/in/jesse-merhi/' },
     ],
     avatar: '/blog/authors/jesse-merhi.jpg',
+  },
+  {
+    name: 'Josh Avant',
+    title: 'MTS',
+    org: 'OpenClaw Foundation',
+    handle: 'josh_avant',
+    links: [
+      { label: '@josh_avant', url: 'https://x.com/josh_avant' },
+    ],
+    avatar: '/avatars/x/josh_avant.jpg',
   },
   {
     name: 'Peter Steinberger',


### PR DESCRIPTION
## Summary
- moves Josh Avant to the third author slot on the auto mode blog post
- updates Josh's shared author profile title to MTS

## Validation
- `bun run build`
- checked generated article HTML for author order and Josh title
