### PR TITLE
fix(blog): add Josh LinkedIn

### DIFF
--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -43,6 +43,7 @@ const authorProfiles: BlogAuthor[] = [
     handle: 'joshavant',
     links: [
       { label: '@joshavant', url: 'https://x.com/joshavant' },
+      { label: 'LinkedIn', url: 'https://www.linkedin.com/in/joshavant/' },
     ],
     avatar: '/avatars/x/joshavant.jpg',
   },


### PR DESCRIPTION
## Summary
- adds Josh Avant's LinkedIn link to his shared blog author profile
- keeps Josh's X link first, followed by LinkedIn

## Validation
- `bun run build`
- checked generated article HTML for Josh X before LinkedIn
