### PR TITLE
refactor: share site footer

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,128 @@
+---
+const navLinks = [
+  { id: 'home', label: 'Home', href: '/' },
+  { id: 'blog', label: 'Blog', href: '/blog' },
+  { id: 'showcase', label: 'Showcase', href: '/showcase' },
+  { id: 'press', label: 'Press', href: '/press' },
+  { id: 'shoutouts', label: 'Shoutouts', href: '/shoutouts' },
+  { id: 'integrations', label: 'Integrations', href: '/integrations' },
+  { id: 'security', label: 'Security', href: '/blog#security' },
+];
+
+const {
+  current,
+  credit = 'full',
+  spacing = 'roomy',
+  showDisclaimer = false,
+} = Astro.props;
+
+const links = navLinks.filter((link) => link.id !== current);
+---
+
+<footer class:list={['footer', `footer--${spacing}`]}>
+  <nav class="footer-nav">
+    {links.map((link, index) => (
+      <>
+        {index > 0 && <span class="footer-separator">·</span>}
+        <a href={link.href}>{link.label}</a>
+      </>
+    ))}
+  </nav>
+  {credit === 'simple' ? (
+    <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞</p>
+  ) : (
+    <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞, a space lobster AI with a <a href="https://soul.md" target="_blank" rel="noopener">soul</a>, by <a href="https://steipete.me" target="_blank" rel="noopener">Peter Steinberger</a> & <a href="https://github.com/openclaw/openclaw#community" target="_blank" rel="noopener">community</a>.</p>
+  )}
+  {showDisclaimer && <p class="disclaimer">Independent project, not affiliated with Anthropic.</p>}
+</footer>
+
+<style>
+  .footer {
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+  }
+
+  .footer--home {
+    margin-top: auto;
+    padding-top: 40px;
+    animation: fadeInUp 0.8s ease-out 0.75s both;
+  }
+
+  .footer--roomy {
+    margin-top: auto;
+    padding-top: 48px;
+  }
+
+  .footer--compact {
+    padding-top: 24px;
+  }
+
+  .footer--article {
+    margin-top: 48px;
+    padding-top: 24px;
+  }
+
+  .footer-nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    column-gap: 8px;
+    row-gap: 8px;
+    margin-bottom: 16px;
+    font-size: 0.95rem;
+  }
+
+  .footer-separator {
+    color: var(--text-muted);
+    margin: 0 4px;
+  }
+
+  .footer a {
+    color: var(--coral-bright);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .footer a:hover {
+    color: var(--cyan-bright);
+  }
+
+  .disclaimer {
+    margin-top: 12px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    opacity: 0.7;
+  }
+
+  @media (max-width: 480px) {
+    .footer-nav {
+      gap: 6px;
+      font-size: 0.85rem;
+    }
+
+    .footer a {
+      display: inline-block;
+    }
+
+    .footer-separator {
+      margin: 0 2px;
+    }
+  }
+
+  @media (min-width: 481px) and (max-width: 768px) {
+    .footer-nav {
+      gap: 10px;
+      font-size: 0.9rem;
+    }
+
+    .footer a {
+      display: inline-block;
+    }
+
+    .footer-separator {
+      margin: 0 6px;
+    }
+  }
+</style>

--- a/src/pages/ecosystem.astro
+++ b/src/pages/ecosystem.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SiteTopbar from '../components/SiteTopbar.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import { siGithub } from 'simple-icons';
 
 const siIcon = (icon: any) => icon.path;
@@ -614,20 +615,7 @@ function logoSrc(project: Project) {
       </div>
     </section>
 
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/">Home</a>
-        <span class="footer-separator">·</span>
-        <a href="/integrations">Integrations</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/showcase">Showcase</a>
-        <span class="footer-separator">·</span>
-        <a href="/press">Press</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞, a space lobster AI with a <a href="https://soul.md" target="_blank" rel="noopener">soul</a>, by <a href="https://steipete.me" target="_blank" rel="noopener">Peter Steinberger</a> & <a href="https://github.com/openclaw/openclaw#community" target="_blank" rel="noopener">community</a>.</p>
-    </footer>
+    <SiteFooter current="ecosystem" spacing="compact" />
   </main>
 </Layout>
 
@@ -1134,33 +1122,6 @@ function logoSrc(project: Project) {
     box-shadow: 0 14px 34px rgba(0, 229, 204, 0.14);
   }
 
-  .footer {
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-    padding-top: 24px;
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-    font-size: 0.95rem;
-  }
-
-  .footer-separator { color: var(--text-muted); }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .footer a:hover { color: var(--cyan-bright); }
 
   @media (max-width: 480px) {
     .container { padding: 24px 16px 60px; }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Icon from '../components/Icon.astro';
 import SectionHeader from '../components/SectionHeader.astro';
 import SiteTopbar from '../components/SiteTopbar.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import testimonials from '../data/testimonials.json';
 import communityBuilds from '../data/community-builds.json';
 import pressArticles from '../data/press.json';
@@ -824,23 +825,7 @@ function formatBlogDate(date: Date): string {
     </section>
 
     <!-- Footer -->
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/showcase">Showcase</a>
-        <span class="footer-separator">·</span>
-        <a href="/press">Press</a>
-        <span class="footer-separator">·</span>
-        <a href="/shoutouts">Shoutouts</a>
-        <span class="footer-separator">·</span>
-        <a href="/integrations">Integrations</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog#security">Security</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞, a space lobster AI with a <a href="https://soul.md" target="_blank" rel="noopener">soul</a>, by <a href="https://steipete.me" target="_blank" rel="noopener">Peter Steinberger</a> & <a href="https://github.com/openclaw/openclaw#community" target="_blank" rel="noopener">community</a>.</p>
-      <p class="disclaimer">Independent project, not affiliated with Anthropic.</p>
-    </footer>
+    <SiteFooter current="home" spacing="home" showDisclaimer />
   </main>
 </Layout>
 
@@ -2019,48 +2004,6 @@ function formatBlogDate(date: Date): string {
     }
   }
 
-  /* Footer */
-  .footer {
-    margin-top: auto;
-    padding-top: 40px;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-    animation: fadeInUp 0.8s ease-out 0.75s both;
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-    font-size: 0.95rem;
-  }
-
-  .footer-separator {
-    color: var(--text-muted);
-    margin: 0 4px;
-  }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .footer a:hover {
-    color: var(--cyan-bright);
-  }
-
-  .footer .disclaimer {
-    margin-top: 12px;
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    opacity: 0.7;
-  }
 
   /* Latest Blog Post */
   .blog-preview {
@@ -2409,20 +2352,6 @@ function formatBlogDate(date: Date): string {
     .testimonial-quote {
       font-size: 0.85rem;
     }
-
-    .footer-nav {
-      gap: 6px;
-      font-size: 0.85rem;
-    }
-
-    .footer a {
-      display: inline-block;
-    }
-
-    .footer-separator {
-      margin: 0 2px;
-    }
-
     /* Quick Start mobile layout */
     .code-header {
       flex-wrap: wrap;
@@ -2483,21 +2412,6 @@ function formatBlogDate(date: Date): string {
     .app-download-btn {
       padding: 12px 20px;
       font-size: 0.9rem;
-    }
-  }
-
-  @media (min-width: 481px) and (max-width: 768px) {
-    .footer-nav {
-      gap: 10px;
-      font-size: 0.9rem;
-    }
-
-    .footer a {
-      display: inline-block;
-    }
-
-    .footer-separator {
-      margin: 0 6px;
     }
   }
 

--- a/src/pages/integrations.astro
+++ b/src/pages/integrations.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Icon from '../components/Icon.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import {
   siWhatsapp, siTelegram, siDiscord, siSignal, siApple, siMatrix, siNextcloud, siZalo,
   siAnthropic, siGoogle, siOllama, siMistralai, siPerplexity, siHuggingface,
@@ -371,22 +372,7 @@ const showcase = [
       </a>
     </section>
 
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/">Home</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/showcase">Showcase</a>
-        <span class="footer-separator">·</span>
-        <a href="/press">Press</a>
-        <span class="footer-separator">·</span>
-        <a href="/shoutouts">Shoutouts</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog#security">Security</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞, a space lobster AI with a <a href="https://soul.md" target="_blank" rel="noopener">soul</a>, by <a href="https://steipete.me" target="_blank" rel="noopener">Peter Steinberger</a> & <a href="https://github.com/openclaw/openclaw#community" target="_blank" rel="noopener">community</a>.</p>
-    </footer>
+    <SiteFooter current="integrations" spacing="compact" />
   </main>
 </Layout>
 
@@ -686,37 +672,6 @@ const showcase = [
     box-shadow: 0 8px 24px rgba(0, 229, 204, 0.4);
   }
 
-  .footer {
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-    padding-top: 24px;
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-    font-size: 0.95rem;
-  }
-
-  .footer-separator {
-    color: var(--text-muted);
-  }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .footer a:hover {
-    color: var(--cyan-bright);
-  }
 
   @media (max-width: 480px) {
     .container {

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import pressArticles from '../data/press.json';
 import { sanitizeUrl } from '../lib/sanitize-url';
 ---
@@ -43,22 +44,7 @@ import { sanitizeUrl } from '../lib/sanitize-url';
       ))}
     </div>
 
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/">Home</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/showcase">Showcase</a>
-        <span class="footer-separator">·</span>
-        <a href="/shoutouts">Shoutouts</a>
-        <span class="footer-separator">·</span>
-        <a href="/integrations">Integrations</a>
-        <span class="footer-separator">·</span>
-        <a href="https://trust.openclaw.ai/">Trust</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞</p>
-    </footer>
+    <SiteFooter current="press" credit="simple" />
   </main>
 </Layout>
 
@@ -236,38 +222,6 @@ import { sanitizeUrl } from '../lib/sanitize-url';
     font-weight: 500;
   }
 
-  .footer {
-    margin-top: auto;
-    padding-top: 48px;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-    font-size: 0.95rem;
-  }
-
-  .footer-separator {
-    color: var(--text-muted);
-  }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .footer a:hover {
-    color: var(--cyan-bright);
-  }
 
   @media (max-width: 720px) {
     .container {

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 
 const effectiveDate = 'March 7, 2026';
 ---
@@ -174,24 +175,7 @@ const effectiveDate = 'March 7, 2026';
       </section>
     </article>
 
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/">Home</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/showcase">Showcase</a>
-        <span class="footer-separator">·</span>
-        <a href="/press">Press</a>
-        <span class="footer-separator">·</span>
-        <a href="/shoutouts">Shoutouts</a>
-        <span class="footer-separator">·</span>
-        <a href="/integrations">Integrations</a>
-        <span class="footer-separator">·</span>
-        <a href="https://trust.openclaw.ai/">Trust</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞</p>
-    </footer>
+    <SiteFooter current="privacy" credit="simple" spacing="article" />
   </main>
 </Layout>
 
@@ -406,38 +390,6 @@ const effectiveDate = 'March 7, 2026';
     }
   }
 
-  .footer {
-    margin-top: 48px;
-    padding-top: 24px;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-    font-size: 0.95rem;
-  }
-
-  .footer-separator {
-    color: var(--text-muted);
-  }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .footer a:hover {
-    color: var(--cyan-bright);
-  }
 
   @media (max-width: 640px) {
     .container {

--- a/src/pages/shoutouts.astro
+++ b/src/pages/shoutouts.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import testimonials from '../data/testimonials.json';
 import extraTestimonials from '../data/testimonials-extra.json';
 import { getCachedXAvatarSrc, getInitialsAvatarSrc } from '../lib/avatars';
@@ -40,22 +41,7 @@ const allTestimonials = [...testimonials, ...extraTestimonials];
       ))}
     </div>
 
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/">Home</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/showcase">Showcase</a>
-        <span class="footer-separator">·</span>
-        <a href="/press">Press</a>
-        <span class="footer-separator">·</span>
-        <a href="/integrations">Integrations</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog#security">Security</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞, a space lobster AI with a <a href="https://soul.md" target="_blank" rel="noopener">soul</a>, by <a href="https://steipete.me" target="_blank" rel="noopener">Peter Steinberger</a> & <a href="https://github.com/openclaw/openclaw#community" target="_blank" rel="noopener">community</a>.</p>
-    </footer>
+    <SiteFooter current="shoutouts" />
   </main>
 </Layout>
 
@@ -209,38 +195,6 @@ const allTestimonials = [...testimonials, ...extraTestimonials];
     color: var(--coral-bright);
   }
 
-  .footer {
-    margin-top: auto;
-    padding-top: 48px;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-    font-size: 0.95rem;
-  }
-
-  .footer-separator {
-    color: var(--text-muted);
-  }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-    transition: color 0.2s ease;
-  }
-
-  .footer a:hover {
-    color: var(--cyan-bright);
-  }
 
   @media (max-width: 480px) {
     .container {

--- a/src/pages/showcase.astro
+++ b/src/pages/showcase.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import showcaseData from '../data/showcase.json';
 import featuredBuilds from '../data/community-builds.json';
 import { getCachedXAvatarSrc, getInitialsAvatarSrc } from '../lib/avatars';
@@ -111,22 +112,7 @@ const categoryLabels: Record<string, string> = {
       Looking for more? Check out <a href="https://docs.openclaw.ai/start/showcase" target="_blank" rel="noopener">even more examples in our docs</a> →
     </p>
 
-    <footer class="footer">
-      <nav class="footer-nav">
-        <a href="/">Home</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog">Blog</a>
-        <span class="footer-separator">·</span>
-        <a href="/press">Press</a>
-        <span class="footer-separator">·</span>
-        <a href="/shoutouts">Shoutouts</a>
-        <span class="footer-separator">·</span>
-        <a href="/integrations">Integrations</a>
-        <span class="footer-separator">·</span>
-        <a href="/blog#security">Security</a>
-      </nav>
-      <p>Built by <a href="https://molty.me" target="_blank" rel="noopener">Molty</a> 🦞</p>
-    </footer>
+    <SiteFooter current="showcase" credit="simple" />
   </main>
 </Layout>
 
@@ -529,36 +515,6 @@ const categoryLabels: Record<string, string> = {
     text-decoration: underline;
   }
 
-  .footer {
-    margin-top: auto;
-    padding-top: 48px;
-    text-align: center;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
-
-  .footer-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    column-gap: 8px;
-    row-gap: 8px;
-    margin-bottom: 16px;
-  }
-
-  .footer-separator {
-    color: var(--text-muted);
-  }
-
-  .footer a {
-    color: var(--coral-bright);
-    text-decoration: none;
-  }
-
-  .footer a:hover {
-    color: var(--cyan-bright);
-  }
 
   @media (max-width: 640px) {
     .container {


### PR DESCRIPTION
## Summary

- Add a shared `SiteFooter` component for the repeated footer nav and credits
- Replace duplicated footer markup/styles across the 7 footer pages
- Standardize footer Security links to `/blog#security` and remove the retired trust domain from page footers

## Verification

- `bun run build`
- Confirmed all 7 rendered footers include exactly one `/blog#security` link
