### PR TITLE
fix(site): restore Crabline ecosystem banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Dependencies: update Astro to 7.0.4, js-yaml to 5.2.0, RSS to 4.0.19, Simple Icons to 16.24.1, and Sharp to 0.35.3; add Astro 7-compatible Lucide icons and preserve the existing generated HTML whitespace behavior (#172, #176, thanks @dependabot).
 - Ecosystem: add ClawScan, a composable security scanning harness for agent skills (#177, thanks @Patrick-Erichsen).
+- Ecosystem: render the Crabline card from its existing SVG banner instead of requesting a missing PNG.
 - Ecosystem: add ffmpeg-wasm, imsgcrawl, and photoscrawl to the project directory.
 - Website: redirect `openclaw.ai/docs` to the canonical `docs.openclaw.ai` host while preserving deeper paths and queries.
 - Ecosystem: add libterminal to the TypeScript libraries section with terminal banner art.

--- a/src/pages/ecosystem.astro
+++ b/src/pages/ecosystem.astro
@@ -489,7 +489,6 @@ const generatedBannerSlugs = new Set([
   'mcporter',
   'tachikoma',
   'clawpatch',
-  'crabline',
   'clawbench',
   'agent-skills',
   'plugin-inspector',

--- a/tests/assert-built-assets.mjs
+++ b/tests/assert-built-assets.mjs
@@ -52,11 +52,21 @@ assert.ok(
 
 const homePage = readText('dist/index.html');
 const integrationsPage = readText('dist/integrations/index.html');
+const ecosystemPage = readText('dist/ecosystem/index.html');
 
 assertContains(homePage, siX.path, 'dist/index.html');
 assertContains(homePage, siGooglechrome.path, 'dist/index.html');
 assertContains(homePage, siGmail.path, 'dist/index.html');
 assertContains(integrationsPage, siGoogle.path, 'dist/integrations/index.html');
 assertContains(integrationsPage, siX.path, 'dist/integrations/index.html');
+
+const ecosystemAssetPaths = new Set(
+  [...ecosystemPage.matchAll(/(?:src|href)="(\/ecosystem\/[^"#?]+)"/g)].map(
+    ([, assetPath]) => assetPath,
+  ),
+);
+for (const assetPath of ecosystemAssetPaths) {
+  assertFileExists(`dist${assetPath}`);
+}
 
 console.log('built asset compatibility checks passed');


### PR DESCRIPTION
## Summary

- render the Crabline ecosystem card from the existing SVG banner
- verify every rendered `/ecosystem/` asset reference exists in the production build
- document the user-visible fix in the active changelog

## Proof

- `bun test` — 23 passed
- `bun run test:built-assets` — 20-page production build and ecosystem asset checks passed
- black-box production preview — `/ecosystem` returned 200, referenced `/ecosystem/banners/crabline.svg`, and the SVG returned 200 `image/svg+xml` with stable bytes across retries
- stale `/ecosystem/banners/crabline.png` path returned 404, confirming the regression condition
- rendered exact-head browser proof — the Vercel preview visibly renders the Crabline banner; the image reports `complete=true`, `naturalWidth=300`, `naturalHeight=105`, a visible 249×97 px box, the expected SVG `currentSrc`, and zero console warnings/errors
- Auto Review on rebased head `1533f9218f2d365bfc840e698533e719cfd7849c` — clean; no accepted/actionable findings
- public model identifier gate — PASS; no model-bearing surface changed
