### PR TITLE
chore: prevent accidental package publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "openclaw-ai",
+  "private": true,
   "type": "module",
   "version": "1.0.0",
   "scripts": {


### PR DESCRIPTION
## Summary

- mark the Vercel site package as private
- prevent accidental publication of the currently unclaimed `openclaw-ai` npm name

The repository deploys directly from `main`; it has no package release workflow, tags, or GitHub Releases. This guard makes that delivery boundary explicit without changing the site build.

## Proof

- `npm view openclaw-ai` — registry returned 404 / unpublished
- `bun install --frozen-lockfile` — no changes
- `bun test` — 23 passed
- package metadata assertion — `private === true`
- `git diff --check` — clean
- manual review — one-line package metadata safety guard; no runtime or public-site output changes

## Risk

Low: package metadata only. No dependency, lockfile, runtime, version, deployment, or public-site change.