### PR TITLE
Press: add Semafor (Jensen Huang quote, Anthropic exclusive) and MIT Technology Review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Press: add Semafor's enterprise piece with Jensen Huang's "every company needs an OpenClaw strategy" quote (featured), Semafor's Anthropic-builds-its-own-OpenClaw exclusive, and MIT Technology Review on China's OpenClaw gold rush.
 - Press: sort coverage strictly newest-first with machine-readable dates, demote the Moltbook social-network story from the homepage highlights, and add Microsoft's Build 2026 keynote announcement of OpenClaw running natively on Windows (featured).
 - Integrations: add the ClickClack and Raft channels, list ClawRouter, Gradium, Inworld, OpenCode Go, and the Claude Max API proxy in the provider directory, and update catalog stats (29 chat channels, 62 provider entries) to match current docs.
 - Press: expand the press page with 7 more verified pieces — Fast Company's AI 20 profile of the creator (featured), Business Insider on Google's 'Remy' answer to OpenClaw, GeekWire inside Microsoft's Project Lobster, BBC News and Fortune on China's lobster craze, and two VentureBeat analyses of the OpenClaw moment.

--- a/src/data/press.json
+++ b/src/data/press.json
@@ -20,16 +20,6 @@
     "featured": false
   },
   {
-    "outlet": "Microsoft",
-    "title": "Build 2026: Furthering Windows as the trusted platform for development",
-    "url": "https://blogs.windows.com/windowsdeveloper/2026/06/02/build-2026-furthering-windows-as-the-trusted-platform-for-development/",
-    "displayDate": "Jun 2, 2026",
-    "date": "2026-06-02",
-    "author": "Pavan Davuluri, EVP Windows + Devices",
-    "summary": "Straight from the Build keynote: OpenClaw runs natively on Windows inside Microsoft Execution Containers — “the Windows node and gateway run contained, so your system stays secure.”",
-    "featured": true
-  },
-  {
     "outlet": "TechCrunch",
     "title": "Microsoft launches Scout, an OpenClaw-inspired personal assistant",
     "url": "https://techcrunch.com/2026/06/02/microsoft-launches-scout-an-openclaw-inspired-personal-assistant/",
@@ -37,6 +27,16 @@
     "date": "2026-06-02",
     "author": "Russell Brandom",
     "summary": "The clearest validation yet: Microsoft ships a personal assistant openly inspired by OpenClaw, bringing the agent workflows the lobster made mainstream to the Microsoft 365 ecosystem.",
+    "featured": true
+  },
+  {
+    "outlet": "Microsoft",
+    "title": "Build 2026: Furthering Windows as the trusted platform for development",
+    "url": "https://blogs.windows.com/windowsdeveloper/2026/06/02/build-2026-furthering-windows-as-the-trusted-platform-for-development/",
+    "displayDate": "Jun 2, 2026",
+    "date": "2026-06-02",
+    "author": "Pavan Davuluri, EVP Windows + Devices",
+    "summary": "Straight from the Build keynote: OpenClaw runs natively on Windows inside Microsoft Execution Containers — “the Windows node and gateway run contained, so your system stays secure.”",
     "featured": true
   },
   {
@@ -80,6 +80,26 @@
     "featured": false
   },
   {
+    "outlet": "Semafor",
+    "title": "Anthropic eyes its own version of OpenClaw",
+    "url": "https://www.semafor.com/article/04/03/2026/anthropic-eyes-its-own-version-of-openclaw",
+    "displayDate": "Apr 3, 2026",
+    "date": "2026-04-03",
+    "author": "Rachyl Jones",
+    "summary": "The trifecta completes: after Microsoft and Google, Anthropic is building its own answer to OpenClaw as customer demand for agent platforms keeps growing.",
+    "featured": false
+  },
+  {
+    "outlet": "Semafor",
+    "title": "OpenClaw is coming for businesses",
+    "url": "https://www.semafor.com/article/03/27/2026/openclaw-is-coming-for-businesses",
+    "displayDate": "Mar 27, 2026",
+    "date": "2026-03-27",
+    "author": "Rachyl Jones",
+    "summary": "“Every company in the world today needs to have an OpenClaw strategy” — Nvidia CEO Jensen Huang, as Semafor charts the lobster’s arrival in the enterprise.",
+    "featured": true
+  },
+  {
     "outlet": "Fortune",
     "title": "‘Raise a lobster’: How OpenClaw is the latest craze transforming China’s AI sector",
     "url": "https://fortune.com/2026/03/14/openclaw-china-ai-agent-boom-open-source-lobster-craze-minimax-qwen/",
@@ -97,6 +117,16 @@
     "date": "2026-03-12",
     "author": "Evelyn Cheng and Dylan Butts",
     "summary": "The lobster rush goes global: Tencent, Alibaba, and Baidu race to offer one-click OpenClaw deployments as adoption spreads across China’s tech industry.",
+    "featured": false
+  },
+  {
+    "outlet": "MIT Technology Review",
+    "title": "Hustlers are cashing in on China’s OpenClaw AI craze",
+    "url": "https://www.technologyreview.com/2026/03/11/1134179/china-openclaw-gold-rush/",
+    "displayDate": "Mar 11, 2026",
+    "date": "2026-03-11",
+    "author": "Caiwei Chen",
+    "summary": "MIT Technology Review on the OpenClaw gold rush: a cottage industry of installers, preconfigured lobster hardware, and district governments backing claw ventures across China.",
     "featured": false
   },
   {
@@ -140,13 +170,13 @@
     "featured": false
   },
   {
-    "outlet": "TechCrunch",
-    "title": "OpenClaw creator Peter Steinberger joins OpenAI",
-    "url": "https://techcrunch.com/2026/02/15/openclaw-creator-peter-steinberger-joins-openai/",
+    "outlet": "Business Insider",
+    "title": "OpenClaw's creator is heading to OpenAI. He says it could've been a 'huge company,' but building one didn't excite him.",
+    "url": "https://www.businessinsider.com/sam-altman-hires-openclaw-creator-peter-steinberger-personal-ai-agents-2026-2",
     "displayDate": "Feb 15, 2026",
     "date": "2026-02-15",
-    "author": "Anthony Ha",
-    "summary": "A clean, positive headline around the next chapter for OpenClaw: founder momentum, OpenAI backing, and the long-term foundation path.",
+    "author": "Business Insider",
+    "summary": "A positive business-profile angle on OpenClaw’s breakout moment and why Steinberger chose leverage and reach over starting another company.",
     "featured": false
   },
   {
@@ -160,13 +190,13 @@
     "featured": false
   },
   {
-    "outlet": "Business Insider",
-    "title": "OpenClaw's creator is heading to OpenAI. He says it could've been a 'huge company,' but building one didn't excite him.",
-    "url": "https://www.businessinsider.com/sam-altman-hires-openclaw-creator-peter-steinberger-personal-ai-agents-2026-2",
+    "outlet": "TechCrunch",
+    "title": "OpenClaw creator Peter Steinberger joins OpenAI",
+    "url": "https://techcrunch.com/2026/02/15/openclaw-creator-peter-steinberger-joins-openai/",
     "displayDate": "Feb 15, 2026",
     "date": "2026-02-15",
-    "author": "Business Insider",
-    "summary": "A positive business-profile angle on OpenClaw’s breakout moment and why Steinberger chose leverage and reach over starting another company.",
+    "author": "Anthony Ha",
+    "summary": "A clean, positive headline around the next chapter for OpenClaw: founder momentum, OpenAI backing, and the long-term foundation path.",
     "featured": false
   },
   {


### PR DESCRIPTION
A wide sweep for additional linkable press across international outlets, prestige magazines, and newsletters. Three pieces made the cut (22 total on /press now), all URL-verified live and tone-checked:

- **Semafor — "OpenClaw is coming for businesses"** (Rachyl Jones, Mar 27) — carries Nvidia CEO Jensen Huang's quote: *"Every company in the world today needs to have an OpenClaw strategy."* Marked featured — arguably the strongest third-party quote on the wall.
- **Semafor — "Anthropic eyes its own version of OpenClaw"** (Rachyl Jones, Apr 3, exclusive) — completes the big-three set: Microsoft, Google, and Anthropic all building answers to OpenClaw.
- **MIT Technology Review — "Hustlers are cashing in on China's OpenClaw AI craze"** (Caiwei Chen, Mar 11) — the installer cottage industry, preconfigured lobster hardware, and district governments backing claw ventures.

## Swept and ruled out

NYT / Guardian / WaPo / Ars Technica (no positive coverage — Ars only has a security piece), Forbes / IEEE Spectrum / Nikkei / Rest of World (nothing), German press (heise and derStandard covered the OpenAI signing — redundant with three existing entries — or ran negative framings), The Economist (tangential China-policy piece), SCMP (stock-market angle), ZDNet / The Register (indirect or negative), plus assorted vendor blogs and how-to guides that aren't press.

Entries slot in via the date-sorted rendering from #190. `bun test` (23/23) and `bun run build` (20 pages) pass.
