### PR TITLE
Keep hero eyes dark in light mode

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -147,8 +147,8 @@ const asciiAurora = (() => {
           <path d="M45 15 Q35 5 30 8" stroke="var(--coral-bright)" stroke-width="2" stroke-linecap="round"/>
           <path d="M75 15 Q85 5 90 8" stroke="var(--coral-bright)" stroke-width="2" stroke-linecap="round"/>
           <!-- Eyes -->
-          <circle cx="45" cy="35" r="6" fill="var(--bg-deep)"/>
-          <circle cx="75" cy="35" r="6" fill="var(--bg-deep)"/>
+          <circle cx="45" cy="35" r="6" fill="#101012"/>
+          <circle cx="75" cy="35" r="6" fill="#101012"/>
           <circle cx="46" cy="34" r="2" fill="var(--cyan-bright)"/>
           <circle cx="76" cy="34" r="2" fill="var(--cyan-bright)"/>
           <defs>

--- a/tests/static-assets.test.ts
+++ b/tests/static-assets.test.ts
@@ -278,6 +278,15 @@ describe('static public assets', () => {
     expect(homePage).not.toContain('<span class="cta-sub">Download skills</span>');
   });
 
+  test('keeps the homepage hero lobster eyes dark in both themes', () => {
+    const homePage = readText('src/pages/index.astro');
+
+    expect(homePage).toContain('<circle cx="45" cy="35" r="6" fill="#101012"/>');
+    expect(homePage).toContain('<circle cx="75" cy="35" r="6" fill="#101012"/>');
+    expect(homePage).not.toContain('<circle cx="45" cy="35" r="6" fill="var(--bg-deep)"/>');
+    expect(homePage).not.toContain('<circle cx="75" cy="35" r="6" fill="var(--bg-deep)"/>');
+  });
+
   test('omits the redundant integrations section navigation', () => {
     const integrationsPage = readText('src/pages/integrations.astro');
 


### PR DESCRIPTION
## Summary
- pin the homepage hero lobster eye fill to dark ink so it stays visible in light mode
- add a static regression test that guards against the eyes using the theme background token again

## Behavior proof
Light-mode homepage hero screenshot, cropped to browser content only with no address bar or local URL:

![OpenClaw homepage hero in light mode with dark lobster eyes](https://gist.githubusercontent.com/Solvely-Colin/076542012d20014788e1511a31c4afff/raw/3c19a58660a83bb4ed677d64ad26de2b9bcf7d85/light-mode-hero.svg)

Runtime probe from the same light-mode render confirmed both hero eye circles use the fixed dark fill:

```text
{
  "theme": "light",
  "eyes": ["#101012", "#101012"]
}
```

The served HTML also shows both hero eye circles using the fixed dark fill:

```html
<circle cx="45" cy="35" r="6" fill="#101012" data-astro-cid-lcdefpme></circle>
<circle cx="75" cy="35" r="6" fill="#101012" data-astro-cid-lcdefpme></circle>
```

## Verification
`bun test`:

```text
(pass) static public assets > keeps the homepage hero lobster eyes dark in both themes [0.09ms]

 25 pass
 0 fail
 179 expect() calls
Ran 25 tests across 2 files. [65.00ms]
```

`bun run build`:

```text
16:06:38   ├─ /index.html (+10ms)
16:06:38 ✓ Completed in 764ms.

16:06:38 [build] ✓ Completed in 1.33s.
16:06:38 [build] 29 page(s) built in 1.71s
16:06:38 [build] Complete!
```