### PR TITLE
feat(homepage): reveal blog thumbnail color on hover

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2721,6 +2721,13 @@ const asciiAurora = renderAsciiAurora();
     width: 100%;
     height: 100%;
     object-fit: cover;
+    filter: grayscale(1);
+    transition: filter 0.2s ease;
+  }
+
+  .blog-feature:is(:hover, :focus-visible) .blog-thumb img,
+  .blog-recent:is(:hover, :focus-visible) .blog-thumb img {
+    filter: grayscale(0);
   }
 
   /* Dither placeholder for posts without artwork */


### PR DESCRIPTION
## Summary

This PR proposes a small interaction polish for the homepage blog preview:

- desaturate post thumbnails at rest
- reveal full color only when the corresponding card is hovered or keyboard-focused
- keep the other cards unchanged

## Screenshots

### Default

![Homepage blog thumbnails in the proposed default grayscale state](https://polite-mango-ww7h.here.now/blog-thumbnails-default.jpg)

### First post hovered

![The proposed hover state reveals color only on the first blog post](https://polite-mango-ww7h.here.now/blog-thumbnails-hover.jpg)

## Validation

- `bun test` — 28 passed
- `bun run build` — 31 pages built
- `node tests/assert-built-assets.mjs`
- Browser verification at 1280 × 900 for default, hover, and keyboard-focus states
