### PR TITLE
test: align PowerShell installer assertion

### DIFF
--- a/scripts/test-install-ps1-unit.sh
+++ b/scripts/test-install-ps1-unit.sh
@@ -54,7 +54,9 @@ for script in "${SCRIPTS[@]}"; do
   require_contains "$script" 'function Test-BooleanSuccessResult {'
   require_contains "$script" 'function Resolve-NpmOpenClawInstallSpec {'
   # shellcheck disable=SC2016
-  require_contains "$script" 'Invoke-NpmCommand -Arguments (@("install", "-g") + $freshnessArgs + @("$installSpec"))'
+  require_contains "$script" '$npmInstallArguments = @("install", "-g") + $freshnessArgs + @("$installSpec")'
+  # shellcheck disable=SC2016
+  require_contains "$script" 'Invoke-NpmCommand -Arguments $npmInstallArguments'
   # shellcheck disable=SC2016
   require_contains "$script" 'return "$PackageName@$trimmedTag"'
   require_contains "$script" 'return (Fail-Install -Code 2)'


### PR DESCRIPTION
## Summary

- update the PowerShell installer source assertion for the canonical `$npmInstallArguments` refactor
- continue verifying both argument construction and execution

## Root cause

`public/install.ps1` now constructs the npm install argument array once so its retry reuses the exact command. The source-level unit test still searched for the removed inline invocation, making `Install Smoke / install-sh-unit` fail on `main` and every current PR.

## Proof

- `bun install --frozen-lockfile`: passed
- `bun run build`: 31 pages built
- `bash scripts/test-install-ps1-unit.sh`: passed
- `shellcheck scripts/test-install-ps1-unit.sh`: passed
- `bun test`: 39 pass, 0 fail
- `git diff --check`: passed
- AutoReview: clean; no accepted/actionable findings; correctness confidence 0.98

No changelog entry: test-only correction with no user-visible runtime change.
