### PR TITLE
fix(security): enable HSTS for subdomains

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
           "value": "strict-origin-when-cross-origin"
         },
         {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains"
+        },
+        {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=()"
         }


### PR DESCRIPTION
## Summary

- add HSTS to the global Vercel response headers
- use the exact policy `max-age=63072000; includeSubDomains`
- deliberately defer the `preload` token and preload-list submission

This branch now contains only the HSTS change. The unrelated installer fallback commit has been removed.

Maintainer decision: Peter approved `includeSubDomains` now. The `preload` token and preload-list submission remain deferred. Because fork preview deployment is unavailable at the Vercel authorization gate, the requested live verification is intentionally against production immediately after merge.

## Why

Vercel already serves the apex over HTTPS and emits a two-year HSTS max age. Adding `includeSubDomains` makes the approved policy explicit for the full domain tree after a browser receives the apex response.

## Verification

- exact JSON policy assertion passes
- `bun run build`
- Codex autoreview: clean, no accepted/actionable findings
- exact-head Install Matrix run 30252769310 passes on all four Linux targets
- exact-head Install Smoke run 30252769236 passes the root/non-root smoke, shell checks, cross-platform checks, and all Windows verification jobs; only the two git-tag smoke jobs fail on the known excluded `v2026.7.1-2` tag mismatch tracked separately

## Production verification

Verified at 2026-07-27 09:21 UTC after merge commit `b28a95d6bda548ff3fbfe1ff1bb7658354608616`:

- `https://openclaw.ai/` returns HTTP 200 with `Strict-Transport-Security: max-age=63072000; includeSubDomains`.
- `https://blog.openclaw.ai/` returns an HTTPS 308 with its independent Vercel HSTS value `max-age=63072000`, then redirects to the apex response carrying the new `includeSubDomains` policy.
- No tested response contains the deferred `preload` token.

The apex policy is the browser-enforced source of HSTS coverage for the `openclaw.ai` domain tree; a subdomain does not need to repeat `includeSubDomains` for that inheritance to apply.
