### PR TITLE
fix(install): fall back to base git tag for npm republish versions

### DIFF
--- a/public/install-cli.sh
+++ b/public/install-cli.sh
@@ -795,6 +795,39 @@ checkout_git_openclaw_ref() {
 
   git -C "$repo_dir" fetch --tags origin
 
+  if try_checkout_git_openclaw_tag_or_sha "$repo_dir" "$ref"; then
+    return 0
+  fi
+
+  # npm republish versions (2026.7.1-2) often lack a matching git tag.
+  # Fall back to the base release tag (v2026.7.1) when present.
+  local fallback_ref
+  fallback_ref="$(npm_republish_git_tag_fallback "$ref" || true)"
+  if [[ -n "$fallback_ref" ]]; then
+    log "Git tag ${ref} not found; trying ${fallback_ref}"
+    if try_checkout_git_openclaw_tag_or_sha "$repo_dir" "$fallback_ref"; then
+      return 0
+    fi
+  fi
+
+  fail "Requested git version not found: ${ref}"
+}
+
+# Map npm republish tags (vX.Y.Z-N) to the base git release tag (vX.Y.Z).
+# Returns empty when the ref is not an npm-style republish suffix.
+npm_republish_git_tag_fallback() {
+  local ref="$1"
+  if [[ "$ref" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$ ]]; then
+    echo "v${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+try_checkout_git_openclaw_tag_or_sha() {
+  local repo_dir="$1"
+  local ref="$2"
+
   if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
     git -C "$repo_dir" checkout --detach "$ref"
     return 0
@@ -805,7 +838,7 @@ checkout_git_openclaw_ref() {
     return 0
   fi
 
-  fail "Requested git version not found: ${ref}"
+  return 1
 }
 
 git_install_lockfile_flag() {

--- a/public/install.sh
+++ b/public/install.sh
@@ -2356,6 +2356,40 @@ checkout_git_openclaw_ref() {
 
     run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --tags origin
 
+    if try_checkout_git_openclaw_tag_or_sha "$repo_dir" "$ref"; then
+        return 0
+    fi
+
+    # npm republish versions (2026.7.1-2) often lack a matching git tag.
+    # Fall back to the base release tag (v2026.7.1) when present.
+    local fallback_ref
+    fallback_ref="$(npm_republish_git_tag_fallback "$ref" || true)"
+    if [[ -n "$fallback_ref" ]]; then
+        ui_info "Git tag ${ref} not found; trying ${fallback_ref}"
+        if try_checkout_git_openclaw_tag_or_sha "$repo_dir" "$fallback_ref"; then
+            return 0
+        fi
+    fi
+
+    ui_error "Requested git version not found: ${ref}"
+    return 1
+}
+
+# Map npm republish tags (vX.Y.Z-N) to the base git release tag (vX.Y.Z).
+# Returns empty when the ref is not an npm-style republish suffix.
+npm_republish_git_tag_fallback() {
+    local ref="$1"
+    if [[ "$ref" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)$ ]]; then
+        echo "v${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+try_checkout_git_openclaw_tag_or_sha() {
+    local repo_dir="$1"
+    local ref="$2"
+
     if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
         return 0
@@ -2366,7 +2400,6 @@ checkout_git_openclaw_ref() {
         return 0
     fi
 
-    ui_error "Requested git version not found: ${ref}"
     return 1
 }
 


### PR DESCRIPTION
## What Problem This Solves

openclaw.ai git install smoke (`install-sh-git-smoke`, `install-cli-git-smoke`) fails when npm `latest` is a republish version such as `2026.7.1-2` that has no matching GitHub tag. The installers resolve latest to `v2026.7.1-2` and hard-fail with `Requested git version not found`. That currently reds PR CI (including security PRs that only touch `vercel.json`) and breaks real git installs that track npm latest.

## Changes

Companion sync of openclaw/openclaw#112754:

- `public/install.sh` and `public/install-cli.sh`: when exact tag `vX.Y.Z-N` is missing, fall back to base release tag `vX.Y.Z`

## Evidence

```console
$ npm view openclaw version
2026.7.1-2

$ # before: exact tag missing
tag_republish=missing
tag_base=present
Requested git version not found: v2026.7.1-2

$ # after: fallback checkout
Git tag v2026.7.1-2 not found; trying v2026.7.1
Checking out v2026.7.1
MATCH_base_tag=yes
```

Upstream unit coverage lives in openclaw/openclaw#112754 (`install-sh` / `install-cli` tests).

## Test plan

- [ ] CI install-sh-git-smoke / install-cli-git-smoke green on this PR
- [x] bash -n on both public install scripts
- [x] Real openclaw clone checkout of v2026.7.1-2 falls back to v2026.7.1

## Related

- openclaw/openclaw#112754 (source of truth)
