### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Docs: rewrite the README as a concise contributor front door and move hosted installer details into a dedicated guide.
 - Windows installer: sync the OpenClaw 2026.7.1 runtime validation fix so upgraded Node 22/24 installs are checked through the active executable.
 - Security: prevent blog and author JSON-LD metadata from breaking out of its script element (#208, thanks @SebTardif).
 - Security: remove raw HTML from blog descriptions so frontmatter cannot inject active markup (#207, thanks @SebTardif).

--- a/README.md
+++ b/README.md
@@ -1,76 +1,79 @@
-# openclaw.ai
+# openclaw.ai 🦞 — The lobster's front door
 
-Landing page for [OpenClaw](https://github.com/openclaw/openclaw) — your personal AI assistant.
+[![Installer tests](https://img.shields.io/github/actions/workflow/status/openclaw/openclaw.ai/install-smoke.yml?branch=main&style=flat-square&label=installer%20tests)](https://github.com/openclaw/openclaw.ai/actions/workflows/install-smoke.yml)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fopenclaw.ai&style=flat-square&label=openclaw.ai)](https://openclaw.ai)
 
-**Live**: [openclaw.ai](https://openclaw.ai)
+`openclaw.ai` is the public website for [OpenClaw](https://github.com/openclaw/openclaw). This repository is for contributors maintaining the landing pages, blog, ecosystem directory, and hosted installer endpoints; product documentation lives at [docs.openclaw.ai](https://docs.openclaw.ai).
 
-## Pages
+![OpenClaw — your personal AI assistant](public/og-image.png)
 
-- `/` — Main landing page with Quick Start, features, and testimonials
-- `/integrations` — Visual grid of all supported chat providers, AI models, platforms, and tools
-- `/shoutouts` — Community testimonials and mentions
+## Install
 
-## Tech Stack
+The website is source-only and uses Bun:
 
-- [Astro](https://astro.build/) — Static site generator
-- [Vercel](https://vercel.com/) — Hosting
-- Custom CSS — No framework, just vibes
+```sh
+git clone https://github.com/openclaw/openclaw.ai.git
+cd openclaw.ai
+bun install --frozen-lockfile
+```
 
-## Development
+The package manifest is private, and the site is not distributed through npm, Homebrew, or GitHub Releases.
 
-```bash
-bun install
+## Quick start
+
+Start the local Astro development server:
+
+```sh
 bun run dev
 ```
 
+Open [http://localhost:4321](http://localhost:4321). Changes under `src/` reload automatically.
+
+## Site map
+
+| Surface | Path | Purpose |
+| --- | --- | --- |
+| Home | [`/`](https://openclaw.ai/) | Product overview and first-run path |
+| Integrations | [`/integrations`](https://openclaw.ai/integrations) | Channels, models, platforms, and tools |
+| Ecosystem | [`/ecosystem`](https://openclaw.ai/ecosystem) | OpenClaw-related projects |
+| Showcase | [`/showcase`](https://openclaw.ai/showcase) | Community projects and examples |
+| Blog | [`/blog`](https://openclaw.ai/blog) | Project articles and announcements |
+| Podcast | [`/podcast`](https://openclaw.ai/podcast) | ClawCast episodes |
+| Press | [`/press`](https://openclaw.ai/press) | Selected coverage |
+| Shoutouts | [`/shoutouts`](https://openclaw.ai/shoutouts) | Community mentions |
+
+The canonical product docs remain on [docs.openclaw.ai](https://docs.openclaw.ai); this site summarizes and routes to them.
+
+## Hosted installers
+
+The production site serves the macOS/Linux, CLI-only, and Windows OpenClaw installers from `public/`. Their supported runtimes, install methods, maintenance contract, and troubleshooting notes are in [docs/installers.md](docs/installers.md).
+
+Installer changes need both local tests and live-path verification because these files are executable user entry points. The main GitHub Actions checks are [Install Smoke](https://github.com/openclaw/openclaw.ai/actions/workflows/install-smoke.yml) and [Install Matrix](https://github.com/openclaw/openclaw.ai/actions/workflows/install-matrix.yml).
+
+## Deployment
+
+The site builds as static Astro output and is served by Vercel. [`vercel.json`](vercel.json) owns production redirects, headers, and cache rules; [`astro.config.mjs`](astro.config.mjs) owns the canonical site URL and build output.
+
 ## Contributing
 
-Read [VISION.md](./VISION.md) for product direction and [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a PR.
+Read [VISION.md](VISION.md) for the product boundary and [CONTRIBUTING.md](CONTRIBUTING.md) for accepted changes before opening a pull request. Broad redesigns and editorial work require maintainer direction.
 
-## Build
+## Development
 
-```bash
+```sh
+bun test
 bun run build
 bun run preview
 ```
 
-## Deploy
+The preview server serves the production build at [http://localhost:4321](http://localhost:4321). Use `bun run test:built-assets` when changing generated routes or public assets.
 
-Automatically deployed to Vercel on push to `main`.
+## Project links
 
-## Install Scripts
+- [OpenClaw repository](https://github.com/openclaw/openclaw)
+- [Documentation](https://docs.openclaw.ai)
+- [Discord](https://discord.gg/openclaw)
 
-The landing page hosts installer scripts:
+## License
 
-- **macOS/Linux**: `curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash`
-- **macOS/Linux (CLI only, no onboarding)**: `curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash`
-- **Windows**: `powershell -c "irm https://openclaw.ai/install.ps1 | iex"`
-
-Installer UI controls (macOS/Linux `install.sh`):
-- Gum UI is auto-detected; interactive terminals get richer status output, non-interactive shells fall back to plain output automatically.
-- Windows `install.ps1` keeps `irm ... | iex` failures in the current PowerShell session while preserving non-zero exits for direct script-file automation.
-
-These scripts:
-1. Install Homebrew (macOS) or detect package managers (Windows)
-2. Install Node.js 22+ if needed
-3. Install openclaw globally via npm, or from a pnpm-backed git checkout with `--install-method git`
-4. Run `openclaw doctor --non-interactive` for migrations (upgrades only)
-5. Prompt to run `openclaw onboard` (new installs)
-
-Switching after install:
-- npm package to git checkout: `openclaw update --channel dev`
-- git checkout to npm package: `openclaw update --channel stable`
-- installer-forced switch: rerun the installer with `--install-method git` or `--install-method npm`
-
-Source checkouts use the OpenClaw pnpm workspace. Keep hackable/dev-channel copy
-pointing at `pnpm install`; root `npm install` is for packaged installs, not
-source trees.
-
-Troubleshooting:
-- macOS first-run Homebrew bootstrap needs an Administrator account. If install fails with a sudo/admin error, use an admin account (or add the current user to the `admin` group) and rerun the installer.
-
-## Related
-
-- [OpenClaw](https://github.com/openclaw/openclaw) — Main repository
-- [Docs](https://docs.openclaw.ai) — Documentation
-- [Discord](https://discord.gg/openclaw) — Community
+This repository does not currently declare a license.

--- a/docs/installers.md
+++ b/docs/installers.md
@@ -1,0 +1,79 @@
+# Hosted installer endpoints
+
+`openclaw.ai` serves three OpenClaw installers. These are product entry points, not installation methods for developing this website repository.
+
+Review downloaded scripts before running them. The macOS/Linux installers require Node.js 22.22.3+, 24.15.0+, 25.9.0+, or a later major; when no supported runtime is active, they install or select one. The Windows installer also supports its bundled Node.js 26 bootstrap path.
+
+## Endpoints
+
+### macOS and Linux
+
+The main installer uses npm by default and offers onboarding after installation:
+
+```sh
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash
+```
+
+For a git checkout instead of the published npm package:
+
+```sh
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash -s -- --install-method git
+```
+
+### macOS and Linux, CLI-only
+
+The CLI installer is non-interactive and skips onboarding by default:
+
+```sh
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash
+```
+
+### Windows
+
+Run the PowerShell installer in the current session:
+
+```powershell
+powershell -c "irm https://openclaw.ai/install.ps1 | iex"
+```
+
+The script detects Winget, Chocolatey, or Scoop when a supported Node.js runtime is unavailable, with a user-local portable Node.js fallback.
+
+## What the installers manage
+
+Depending on the endpoint and selected method, the installers:
+
+1. install Homebrew on macOS when needed, or detect a Windows package manager;
+2. validate or install a supported Node.js runtime;
+3. install OpenClaw globally through npm, or build a pnpm-backed git checkout when `--install-method git` is selected;
+4. run `openclaw doctor --non-interactive` from the main and Windows flows for migrations on upgrades and git installs; and
+5. offer onboarding unless it is disabled or the CLI-only installer is used.
+
+Source checkouts use the OpenClaw pnpm workspace. Run `pnpm install` inside those checkouts; root `npm install` is for packaged installs, not source development.
+
+## Switching install channels
+
+An existing OpenClaw installation can switch between a development checkout and the stable npm package:
+
+```sh
+openclaw update --channel dev
+openclaw update --channel stable
+```
+
+To force the method during installation, rerun the main installer with `--install-method git` or `--install-method npm`.
+
+## Interface behavior
+
+On macOS and Linux, the main installer detects interactive terminals and uses Gum for richer status output when available. Non-interactive sessions fall back to plain output. The Windows installer preserves non-zero exits for direct script-file automation while returning piped `irm ... | iex` failures to the current PowerShell session.
+
+## Troubleshooting
+
+The first Homebrew bootstrap on macOS requires an Administrator account. If it fails with an admin or `sudo` error, use an Administrator account or add the current user to the `admin` group, sign out and back in, then rerun the installer.
+
+Inspect the local command contracts without installing anything:
+
+```sh
+bash public/install.sh --help
+bash public/install-cli.sh --help
+```
+
+The CI workflows exercise dry runs, shell unit tests, Linux distribution matrices, container installs, and Windows installs. See [Install Smoke](https://github.com/openclaw/openclaw.ai/actions/workflows/install-smoke.yml) and [Install Matrix](https://github.com/openclaw/openclaw.ai/actions/workflows/install-matrix.yml).


### PR DESCRIPTION
## Summary

Before, the README mixed a short contributor setup with detailed product-installer behavior and had no standard badge row or explicit first-success path. After, it is a concise front door for the public site: dynamic health badges, source install, a 60-second local quick start, a current site map, clear ownership boundaries, development commands, project links, and an honest license note.

## Moved and dropped

- Moved installer endpoints, supported Node.js floors, npm/git methods, channel switching, UI behavior, and troubleshooting to `docs/installers.md`.
- Replaced the stale generic "Node.js 22+" claim with the exact floors enforced by the current scripts, including later majors.
- Dropped the marketing aside "No framework, just vibes."
- Dropped the claim that every push to `main` deploys automatically because that Vercel integration is not verifiable from the repository; the README now describes only the checked-in Astro and Vercel configuration.
- The repository has no license file, so the README states that no license is currently declared instead of inventing one or rendering a misleading license badge.

## Verification

- `bun install --frozen-lockfile` — passed with Bun 1.3.14.
- `bun test` — 39 passed, 0 failed.
- `bun run build` — 41 static pages built.
- `bun run test:built-assets` — passed.
- `bun run dev` and `bun run preview` — both served `http://localhost:4321` with HTTP 200.
- `bash public/install.sh --help` and `bash public/install-cli.sh --help` — documented flags confirmed; the PowerShell script parameter contract parsed successfully. The live installers were not executed because they mutate the host.
- README shell and PowerShell snippets parsed cleanly from temporary scratch files, which were then removed.
- Every relative link resolves; every external link and installer endpoint returned HTTP 200; both Shields badges returned valid SVGs without `invalid` or `not found` cards.
- Distribution checks: `npm view openclaw-ai version` returned 404, GitHub Releases returned an empty list, and neither local OpenClaw Homebrew tap contained a formula or cask for this site.
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.

## CI

Checks settled against exact head `93f71442e3829144ef7410dda51f9acf44421cbd`. Vercel previews, the Linux matrix, cross-platform dry runs, ShellCheck, installer unit tests, the general install smoke, and all four Windows install jobs passed.

Two unchanged git-install smoke jobs failed on external OpenClaw release state: the installer selected `v2026.7.1-2`, then reported `Requested git version not found: v2026.7.1-2`. This documentation-only PR does not change either workflow or installer. The ClawSweeper dispatch was cancelled after its dispatch steps succeeded; no review check failed on repository content.
