### PR TITLE
chore: update skills CLI to 1.5.22

### DIFF
--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           set -euo pipefail
           # The committed .agents directory keeps updates in universal project scope.
-          output="$(npx --yes skills@1.5.21 update --project --yes 2>&1)"
+          output="$(npx --yes skills@1.5.22 update --project --yes 2>&1)"
           # Headless agent detection also emits an Eve mirror; .agents is canonical here.
           rm -rf agent
           printf '%s\n' "$output"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Press: refresh Featured In with 2026 Q2 coverage — TechCrunch on Microsoft's OpenClaw-inspired Scout, the iOS/Android launch, Red Hat's enterprise-hardening work, and CNBC on China's lobster rush; new homepage highlight order.
 - Testimonials: add 11 new shoutouts from the archive, including @sama, @elonmusk, @garrytan, @growing_daniel, @donasarkar, and @OmarShahine, with cached avatars.
 - Website: homepage facelift — hero call-to-action buttons, aurora glow and film-grain texture, larger section headers with chevron markers, refined feature and blog cards, glowing quick-start terminal, cleaner sponsor logo wall, and a wider 960px layout with more breathing room between sections.
-- Dependencies: update Astro to 7.1.6, js-yaml to 5.2.3, Lucide Astro to 1.28.0, Simple Icons to 16.28.0, Carapace to 0.6.1, the skills CLI to 1.5.21, the installer smoke image to Node 26, and pinned GitHub Actions to Checkout 7.0.1 and Setup Node 7.0.0; keep RSS, Analytics, and Sharp current, and force patched SVGO and PostCSS transitives (#172, #176, #206, #216, thanks @dependabot).
+- Dependencies: update Astro to 7.1.6, js-yaml to 5.2.3, Lucide Astro to 1.28.0, Simple Icons to 16.28.0, Carapace to 0.6.1, the skills CLI to 1.5.22, the installer smoke image to Node 26, and pinned GitHub Actions to Checkout 7.0.1 and Setup Node 7.0.0; keep RSS, Analytics, and Sharp current, and force patched SVGO and PostCSS transitives (#172, #176, #206, #216, thanks @dependabot).
 - Ecosystem: add ClawScan, a composable security scanning harness for agent skills (#177, thanks @Patrick-Erichsen).
 - Ecosystem: render the Crabline card from its existing SVG banner instead of requesting a missing PNG.
 - Ecosystem: add ffmpeg-wasm, imsgcrawl, and photoscrawl to the project directory.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "test": "bun test",
     "test:built-assets": "bun run build && node tests/assert-built-assets.mjs",
-    "skills:install": "npx --yes skills@1.5.21 add openclaw/carapace --skill openclaw-design openclaw-brand openclaw-carapace openclaw-design-system openclaw-marketing-pages openclaw-design-audit --agent codex --copy --yes",
+    "skills:install": "npx --yes skills@1.5.22 add openclaw/carapace --skill openclaw-design openclaw-brand openclaw-carapace openclaw-design-system openclaw-marketing-pages openclaw-design-audit --agent codex --copy --yes",
     "avatars:cache": "node scripts/cache-avatars.mjs",
     "preview": "astro preview"
   },


### PR DESCRIPTION
## Summary

- update the pinned skills CLI from 1.5.21 to 1.5.22 in local and scheduled update paths
- reconcile the existing Unreleased dependency note

## Proof

- `npx --yes skills@1.5.22 update --project --yes`: refreshed all six managed skills with no repository drift
- `bun install --frozen-lockfile`: no changes
- `bun test`: 39 pass, 0 fail
- `bun run test:built-assets`: 41 pages built; compatibility checks passed
- `bun run preview` + `curl`: HTTP 200, 280450 bytes, expected page title
- autoreview: clean, no accepted/actionable findings
