### PR TITLE
feat: add ClawCast episode 7

### DIFF
--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -28,6 +28,38 @@ const spotifyShowUrl = 'https://open.spotify.com/show/033M5Wn9WAAdujY1qAcIYO';
 
 export const podcastEpisodes: PodcastEpisode[] = [
   {
+    number: 7,
+    slug: 'episode-7',
+    title: 'Unfiltered Q&A with OpenClaw Founder Peter Steinberger',
+    hosts: [
+      { name: 'Hannes Rudolph', xUrl: 'https://x.com/hrudolph' },
+      { name: 'Patrick Erichsen', xUrl: 'https://x.com/Pat_Erichsen' },
+    ],
+    guests: [
+      { name: 'Peter Steinberger', xUrl: 'https://x.com/steipete' },
+    ],
+    airedAt: '2026-08-12',
+    youtubeUrl: 'https://www.youtube.com/watch?v=WhkfUnKJuoY',
+    spotifyUrl: 'https://open.spotify.com/episode/5mA2L9xmW76nq4erEKb3MP',
+    spotifyLabel: 'Open in Spotify',
+    listingSummary: 'Peter Steinberger, founder of OpenClaw, joins Hannes Rudolph and Patrick Erichsen for an unfiltered community Q&A about where OpenClaw is headed, the upcoming release, and how agents are changing software development.',
+    description: `An unfiltered Q&A with Peter Steinberger, founder of OpenClaw. Host Hannes Rudolph and co-host Patrick Erichsen put community questions to Peter about where OpenClaw is headed, the upcoming release, and how agents are changing the way software gets built.
+
+Together, they cover cloud-backed multiplayer workflows, using OpenClaw to build OpenClaw, SQLite, team servers, agent-to-agent collaboration, memory, model routing, onboarding, browser control, hardware experiments, and why open source remains OpenClaw’s core differentiator.
+
+Learn more about The OpenClaw Foundation: https://www.openclaw.org
+
+Guests and hosts socials:
+Hannes Rudolph: https://x.com/hrudolph
+Patrick Erichsen: https://x.com/Pat_Erichsen
+Peter Steinberger: https://x.com/steipete
+
+Listen on Spotify: https://open.spotify.com/episode/5mA2L9xmW76nq4erEKb3MP
+
+Recorded live every Wednesday at 11:30 AM PT on Discord.
+Join our Discord: https://discord.com/invite/clawd`,
+  },
+  {
     number: 6,
     slug: 'episode-6',
     title: 'Episode 6',

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -30,7 +30,7 @@ export const podcastEpisodes: PodcastEpisode[] = [
   {
     number: 7,
     slug: 'episode-7',
-    title: 'Episode 7',
+    title: 'Unfiltered Q&A with OpenClaw Founder Peter Steinberger',
     hosts: [
       { name: 'Hannes Rudolph', xUrl: 'https://x.com/hrudolph' },
       { name: 'Patrick Erichsen', xUrl: 'https://x.com/Pat_Erichsen' },

--- a/src/data/podcast.ts
+++ b/src/data/podcast.ts
@@ -30,7 +30,7 @@ export const podcastEpisodes: PodcastEpisode[] = [
   {
     number: 7,
     slug: 'episode-7',
-    title: 'Unfiltered Q&A with OpenClaw Founder Peter Steinberger',
+    title: 'Episode 7',
     hosts: [
       { name: 'Hannes Rudolph', xUrl: 'https://x.com/hrudolph' },
       { name: 'Patrick Erichsen', xUrl: 'https://x.com/Pat_Erichsen' },

--- a/tests/podcast.test.ts
+++ b/tests/podcast.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { podcastEpisodes } from '../src/data/podcast';
+
+describe('podcast episode catalog', () => {
+  test('keeps Episode 7 first with its approved destinations and participants', () => {
+    const episode = podcastEpisodes[0];
+
+    expect(episode).toMatchObject({
+      number: 7,
+      slug: 'episode-7',
+      title: 'Unfiltered Q&A with OpenClaw Founder Peter Steinberger',
+      airedAt: '2026-08-12',
+      youtubeUrl: 'https://www.youtube.com/watch?v=WhkfUnKJuoY',
+      spotifyUrl: 'https://open.spotify.com/episode/5mA2L9xmW76nq4erEKb3MP',
+    });
+    expect(episode.hosts.map(({ name }) => name)).toEqual([
+      'Hannes Rudolph',
+      'Patrick Erichsen',
+    ]);
+    expect(episode.guests.map(({ name }) => name)).toEqual(['Peter Steinberger']);
+    expect(episode.description).toContain('An unfiltered Q&A with Peter Steinberger');
+    expect(episode.description).toContain('Together, they cover');
+  });
+});

--- a/tests/podcast.test.ts
+++ b/tests/podcast.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, test } from 'bun:test';
 import { podcastEpisodes } from '../src/data/podcast';
 
 describe('podcast episode catalog', () => {
+  test('uses the website Episode N title convention', () => {
+    for (const episode of podcastEpisodes) {
+      expect(episode.title).toBe(`Episode ${episode.number}`);
+    }
+  });
+
   test('keeps Episode 7 first with its approved destinations and participants', () => {
     const episode = podcastEpisodes[0];
 
     expect(episode).toMatchObject({
       number: 7,
       slug: 'episode-7',
-      title: 'Unfiltered Q&A with OpenClaw Founder Peter Steinberger',
+      title: 'Episode 7',
       airedAt: '2026-08-12',
       youtubeUrl: 'https://www.youtube.com/watch?v=WhkfUnKJuoY',
       spotifyUrl: 'https://open.spotify.com/episode/5mA2L9xmW76nq4erEKb3MP',

--- a/tests/podcast.test.ts
+++ b/tests/podcast.test.ts
@@ -2,19 +2,13 @@ import { describe, expect, test } from 'bun:test';
 import { podcastEpisodes } from '../src/data/podcast';
 
 describe('podcast episode catalog', () => {
-  test('uses the website Episode N title convention', () => {
-    for (const episode of podcastEpisodes) {
-      expect(episode.title).toBe(`Episode ${episode.number}`);
-    }
-  });
-
   test('keeps Episode 7 first with its approved destinations and participants', () => {
     const episode = podcastEpisodes[0];
 
     expect(episode).toMatchObject({
       number: 7,
       slug: 'episode-7',
-      title: 'Episode 7',
+      title: 'Unfiltered Q&A with OpenClaw Founder Peter Steinberger',
       airedAt: '2026-08-12',
       youtubeUrl: 'https://www.youtube.com/watch?v=WhkfUnKJuoY',
       spotifyUrl: 'https://open.spotify.com/episode/5mA2L9xmW76nq4erEKb3MP',


### PR DESCRIPTION
## Summary
- add Episode 7 as the newest ClawCast entry
- use the approved founder Q&A title, participants, summary, and description
- link the verified public YouTube and Spotify episodes
- add a regression test for catalog ordering and metadata

## Validation
- `pnpm exec astro build`
- `node tests/assert-built-assets.mjs`
- Episode 7 data and built-page assertions

The repository's `bun test` command could not run locally because Bun is not installed on this host; CI remains authoritative for the Bun suite.