### PR TITLE
fix(seo): make podcast video metadata valid

### DIFF
--- a/src/pages/podcast/[episode].astro
+++ b/src/pages/podcast/[episode].astro
@@ -26,6 +26,14 @@ const olderEpisode = podcastEpisodes[episodeIndex + 1];
 const canonicalUrl = `https://openclaw.ai/podcast/${episode.slug}`;
 const shareImage = episode.shareImage ?? '/podcast/clawcast-social-preview.png';
 const discordUrl = 'https://discord.com/invite/clawd';
+const episodeName = `The ClawCast - ${episode.title}`;
+const episodeSummary = getEpisodeSummary(episode);
+const youtubeVideoId = new URL(episode.youtubeUrl).searchParams.get('v');
+
+if (!youtubeVideoId) {
+  throw new Error(`Podcast episode ${episode.slug} is missing a YouTube video ID`);
+}
+
 const displayDescription = episode.description
   .replace(/\n\nLearn more about The OpenClaw Foundation:\s*https:\/\/www\.openclaw\.org/gu, '')
   .replace(/\n\nListen on Spotify:\s*https:\/\/\S+/gu, '')
@@ -75,10 +83,10 @@ const descriptionParagraphs = displayDescription
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'PodcastEpisode',
-  name: `The ClawCast - ${episode.title}`,
+  name: episodeName,
   url: canonicalUrl,
   datePublished: `${episode.airedAt}T12:00:00Z`,
-  description: getEpisodeSummary(episode),
+  description: episodeSummary,
   image: `https://openclaw.ai${shareImage}`,
   partOfSeries: {
     '@type': 'PodcastSeries',
@@ -87,14 +95,18 @@ const structuredData = {
   },
   associatedMedia: {
     '@type': 'VideoObject',
-    contentUrl: episode.youtubeUrl,
+    name: episodeName,
+    description: episodeSummary,
+    thumbnailUrl: `https://i.ytimg.com/vi/${youtubeVideoId}/hqdefault.jpg`,
+    uploadDate: episode.airedAt,
+    embedUrl: `https://www.youtube.com/embed/${youtubeVideoId}`,
   },
 };
 ---
 
 <Layout
   title={`The ClawCast ${episode.title}`}
-  description={getEpisodeSummary(episode)}
+  description={episodeSummary}
   canonicalUrl={canonicalUrl}
   ogImage={shareImage}
   ogImageWidth={1200}

--- a/tests/assert-built-assets.mjs
+++ b/tests/assert-built-assets.mjs
@@ -47,6 +47,12 @@ function assertJsonLdIsParseable(html, context) {
   }
 }
 
+function parseJsonLd(html) {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map(
+    ([, contents]) => JSON.parse(contents),
+  );
+}
+
 assertCopiedByteForByte('public/openclaw-logo-text-dark.png', 'dist/openclaw-logo-text-dark.png');
 assertCopiedByteForByte('public/logo.png', 'dist/logo.png');
 assertCopiedByteForByte('public/granola.png', 'dist/granola.png');
@@ -72,6 +78,39 @@ const ecosystemPage = readText('dist/ecosystem/index.html');
 for (const relativePath of listHtmlFiles('dist')) {
   assertJsonLdIsParseable(readText(relativePath), relativePath);
 }
+
+const podcastThumbnails = new Set();
+const podcastEpisodeFiles = listHtmlFiles('dist/podcast').filter((file) =>
+  /episode-\d+/.test(file),
+);
+for (const relativePath of podcastEpisodeFiles) {
+  const podcastEpisode = parseJsonLd(readText(relativePath)).find(
+    (item) => item['@type'] === 'PodcastEpisode',
+  );
+  const video = podcastEpisode?.associatedMedia;
+
+  assert.equal(video?.['@type'], 'VideoObject', `${relativePath} must describe its video`);
+  assert.equal(video.name, podcastEpisode.name, `${relativePath} must name its video`);
+  assert.equal(
+    video.description,
+    podcastEpisode.description,
+    `${relativePath} must describe its video`,
+  );
+  assert.match(video.thumbnailUrl, /^https:\/\/i\.ytimg\.com\/vi\/[\w-]{11}\/hqdefault\.jpg$/);
+  assert.match(video.uploadDate, /^\d{4}-\d{2}-\d{2}$/);
+  assert.match(video.embedUrl, /^https:\/\/www\.youtube\.com\/embed\/[\w-]{11}$/);
+  assert.equal(
+    video.contentUrl,
+    undefined,
+    `${relativePath} must not use a watch page as contentUrl`,
+  );
+  podcastThumbnails.add(video.thumbnailUrl);
+}
+assert.equal(
+  podcastThumbnails.size,
+  podcastEpisodeFiles.length,
+  'Each podcast episode must use its unique video thumbnail',
+);
 
 assertContains(homePage, siX.path, 'dist/index.html');
 assertContains(homePage, siGooglechrome.path, 'dist/index.html');


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Search Console rejected every podcast episode's video structured data because the nested `VideoObject` omitted required metadata and treated a YouTube watch page as the video content file.

## Why This Change Was Made

Each episode now emits the Google-required video name, unique thumbnail, and upload date plus a description. The invalid `contentUrl` is replaced with the episode's YouTube player `embedUrl`, matching Google's documented distinction between a media file URL and a player URL.

The built-output regression check covers every generated podcast episode, requires unique thumbnails, and rejects watch pages in `contentUrl`.

## User Impact

Podcast episode pages now provide complete, valid video metadata to search crawlers without changing the visible page.

## Evidence

- Pre-fix reproduction: `node tests/assert-built-assets.mjs` failed on `dist/podcast/episode-1/index.html must name its video`.
- `npx --yes bun@1.2.22 test`: 40 passed, 0 failed.
- `npx --yes bun@1.2.22 run test:built-assets`: 42 static pages built; built asset compatibility checks passed.
- All seven generated episode objects contain `name`, `description`, `thumbnailUrl`, `uploadDate`, and `embedUrl`, with no `contentUrl`.
- All seven referenced YouTube thumbnail and player URLs returned HTTP 200.
