### PR TITLE
Add media contact to the press page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.19",
         "@lucide/astro": "^1.28.0",
-        "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
+        "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.2",
         "@vercel/analytics": "^2.0.1",
         "astro": "^7.1.6",
         "js-yaml": "^5.2.3",
@@ -206,7 +206,7 @@
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
-    "@openclaw/carapace": ["@openclaw/carapace@github:openclaw/carapace#3a8bcfb", {}, "openclaw-carapace-3a8bcfb", "sha512-UD1qbCzSKMlvDGt4VYH41dtSf77vGZCzXkpGzmVevpanBM3flhAHU/TIedvm+eYadts49wt3+ipQK5Jmh70ZDw=="],
+    "@openclaw/carapace": ["@openclaw/carapace@github:openclaw/carapace#c6247b0", {}, "openclaw-carapace-c6247b0", "sha512-EaJ2/RGalvfee/3n5FPih2d8ydsyf8yhdG7a5WXTmHkx7JYhISnXbOj79uYgPe7DbA4uLTNF7kD2X3vToVqCng=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.19",
     "@lucide/astro": "^1.28.0",
-    "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.1",
+    "@openclaw/carapace": "git+https://github.com/openclaw/carapace.git#v0.6.2",
     "@vercel/analytics": "^2.0.1",
     "astro": "^7.1.6",
     "js-yaml": "^5.2.3",

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -11,7 +11,7 @@ const outletIcon = (url: string) => `/press/icons/${new URL(url).hostname.replac
 
 <Layout
   title="Press — OpenClaw"
-  description="Coverage of OpenClaw across technology, business, and culture."
+  description="Press coverage and media contact information for OpenClaw."
   canonicalUrl="https://openclaw.ai/press"
 >
   <div class="stars"></div>
@@ -25,6 +25,9 @@ const outletIcon = (url: string) => `/press/icons/${new URL(url).hostname.replac
       </h1>
       <p class="subtitle">
         Reporting on OpenClaw's product, company news, and people, with articles added when outlets report something new and every link pointing to the original piece.
+      </p>
+      <p class="media-contact">
+        Media inquiries: <a href="mailto:press@openclaw.org">press@openclaw.org</a>
       </p>
     </header>
 
@@ -149,6 +152,18 @@ const outletIcon = (url: string) => `/press/icons/${new URL(url).hostname.replac
     margin: 0 auto;
     color: var(--oc-text-secondary);
     font-size: 1.08rem;
+  }
+
+  .media-contact {
+    margin: var(--oc-space-4) auto 0;
+    color: var(--oc-text-muted);
+    font-size: 0.95rem;
+  }
+
+  .media-contact a {
+    color: var(--oc-accent-primary);
+    font-weight: 700;
+    text-underline-offset: 0.2em;
   }
 
   .press-grid {


### PR DESCRIPTION
## Summary

- add `press@openclaw.org` as the visible media contact on `openclaw.ai/press`
- update the page description to mention media contact information
- update Carapace to v0.6.2 so the light-theme contact link uses the current AA-safe accent contract

## Verification

- `bun test` (40 passing)
- `bun run build`
- `node tests/assert-built-assets.mjs`
- Carapace audit: semantic tokens only, no new raw colors or duplicate primitives

## Merge gate

Keep this PR in draft until the `press@openclaw.org` alias is active.

## CI note

The installer unit job currently fails because the latest `main` installer sync no longer matches an existing PowerShell test assertion. This PR does not touch the installer or its tests.